### PR TITLE
Validate URL parameters in archive page and slug routes

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -60,7 +60,13 @@ export default function Post({ post, preview }: PostProps) {
 }
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const data = await getPost(params?.slug as string);
+  const slug = params?.slug as string;
+
+  if (!slug || !/^[a-zA-Z0-9-]+$/.test(slug)) {
+    return { notFound: true };
+  }
+
+  const data = await getPost(slug);
 
   return {
     props: {

--- a/pages/archive-page.tsx
+++ b/pages/archive-page.tsx
@@ -49,8 +49,17 @@ const ArchivePage = ({ posts: { posts }, month, year }: ArchivePageProps) => {
 };
 
 export async function getServerSideProps(context: { query: { month: string; year: string } }) {
-  const { month, year } = context.query;
-  const posts = await getPostsByDate(parseInt(month), parseInt(year));
+  const month = parseInt(context.query.month, 10);
+  const year = parseInt(context.query.year, 10);
+
+  if (isNaN(month) || month < 1 || month > 12) {
+    return { notFound: true };
+  }
+  if (isNaN(year) || year < 2000 || year > new Date().getFullYear()) {
+    return { notFound: true };
+  }
+
+  const posts = await getPostsByDate(month, year);
   return {
     props: { posts, month, year },
   };


### PR DESCRIPTION
## Summary

- `pages/archive-page.tsx` — validates `month` (must be 1–12) and `year` (must be 2000–current year) query params; returns 404 for invalid values instead of passing them raw to GraphQL
- `pages/[slug].tsx` — validates slug contains only alphanumeric characters and hyphens before passing to GraphQL query; returns 404 for anything else

## Test plan

- [ ] Visit `/archive-page?month=1&year=2023` — should work as normal
- [ ] Visit `/archive-page?month=99&year=1900` — should return 404
- [ ] Visit `/archive-page?month=abc&year=xyz` — should return 404
- [ ] Visit a valid post slug — should load normally
- [ ] Visit `/<script>alert(1)</script>` — should return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)