### PR TITLE
perf: replace raw <img> with next/image and fix incorrect sizes prop

### DIFF
--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -150,7 +150,7 @@ export default function HomepageBlock({
       <StyledIconLinkBlock href={url ?? '/'}>
         <p aria-label={title}>{title}</p>
         <StyledIcon>
-          <img src={`/icons/${icon}.png`} alt="icon" />
+          <Image src={`/icons/${icon}.png`} alt="" width={64} height={64} />
         </StyledIcon>
       </StyledIconLinkBlock>
     </Block>

--- a/components/intro.tsx
+++ b/components/intro.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { colours } from '../pages/_app';
 import { IntroProps, JamesImagesProps } from '../lib/types';
 import Image from 'next/image';
@@ -35,9 +35,9 @@ export default function Intro({ jamesImages }: IntroProps) {
     setImageUrls(urls);
   }, [jamesImages]);
 
-  const handleBlockHover = (index: number) => {
+  const handleBlockHover = useCallback((index: number) => {
     setHoveredIndex(index);
-  };
+  }, []);
 
   return (
     <section>
@@ -64,7 +64,7 @@ export default function Intro({ jamesImages }: IntroProps) {
                         alt={jamesAltTag}
                         width={300}
                         height={300}
-                        sizes={jamesImage.srcset}
+                        sizes="12.5vw"
                         quality={75}
                         loading="lazy"
                       />


### PR DESCRIPTION
## Summary

Wednesday performance audit — three targeted fixes across two components.

### `components/homepage-block.tsx`

- **Replace raw `<img>` with `next/image` for icon blocks.** The icon branch of `HomepageBlock` was using a plain `<img src={/icons/${icon}.png}>` tag, bypassing all Next.js image optimisation. Icons are confirmed 64×64px PNGs, so they now benefit from automatic format negotiation (AVIF/WebP via `next.config.js` `formats` setting), CDN caching, and lazy loading. Used `alt=""` (empty) because the adjacent `<p aria-label={title}>` already labels the block semantically.

### `components/intro.tsx`

- **Fix incorrect `sizes` prop on `next/image`.** `sizes={jamesImage.srcset}` was passing a WordPress srcset descriptor string (e.g. `"https://example.com/img.jpg 300w, …"`) as the `sizes` attribute. `sizes` must be a media-condition/length string (e.g. `"12.5vw"`), not a srcset. Without a correct `sizes` value, the browser assumes the image is `100vw` wide and downloads a far larger image than needed. The intro grid has 8 equal columns, so the correct value is `sizes="12.5vw"`.

- **Wrap `handleBlockHover` in `useCallback`.** The function had no dependencies and was recreated on every render. Wrapping it stabilises its reference.

## Test plan

- [ ] Visit the homepage — icon blocks (e.g. Favourites, Wish List) should render their 64×64 icons correctly via the `next/image` optimisation pipeline
- [ ] Hover over tiles in the "WORLD OF WINFIELD" intro grid — images should flip in as before, with no console errors about invalid `sizes` values
- [ ] Check Network tab: icon images should be served as AVIF/WebP where the browser supports it
- [ ] Run `yarn build` — no TypeScript or image config errors expected

https://claude.ai/code/session_01AKekZtEr4n3VXm5DfWevzD