### PR TITLE
perf: fix unstable React keys and unnecessary re-renders on homepage

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,14 @@
     "allow": [
       "Bash(grep -v \":0$\")",
       "Bash(yarn test:*)",
-      "Bash(npx tsc:*)"
+      "Bash(npx tsc:*)",
+      "Bash(git -C /c/Users/james/Documents/GitHub/worldofwinfield-nextjs log --oneline)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)",
+      "Skill(schedule)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ next-env.d.ts
 
 yarn.lock
 /realtime/node_modules
+.claude/settings.local.json

--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -49,13 +49,11 @@ export default function HomepageBlock({
   jamesImages,
   icon,
 }: HomePageBlockTypes) {
-  const [randomColour, setRandomColour] = useState('');
+  const [randomColour] = useState(
+    () => blockColours[Math.floor(Math.random() * blockColours.length)]
+  );
   const [imageSrc, setImageSrc] = useState<BlockImage | null>(null);
   useEffect(() => {
-    const randomIndex = Math.floor(Math.random() * blockColours.length);
-    const randomColour = blockColours[randomIndex];
-    setRandomColour(randomColour);
-
     if (title === 'placeholder') {
       const randomJamesImage = Math.floor(Math.random() * jamesImages.edges.length);
       setImageSrc(jamesImages.edges[randomJamesImage].node.featuredImage as BlockImage);
@@ -66,7 +64,7 @@ export default function HomepageBlock({
     if (title === 'random photo') {
       setImageSrc(image ?? null);
     }
-  }, [title, size, image]);
+  }, [title, size, image, jamesImages]);
 
   const eagerOrLazy = () => {
     if (className?.includes('block-1-') || className?.includes('block-2-')) {

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -37,7 +37,6 @@ export default function PostHeader({
       index2 = Math.floor(Math.random() * blockColours.length);
     }
     return { randomColour1: blockColours[index1], randomColour2: blockColours[index2] };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -49,7 +48,10 @@ export default function PostHeader({
           imageSize={imageSize}
           heroPost={heroPost}
         />
-        {caption && <CaptionOverlay dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(caption) }}></CaptionOverlay>}
+        {caption && (
+          <CaptionOverlay
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(caption) }}></CaptionOverlay>
+        )}
       </ImageContainer>
       <StyledLink href={`/${slug}`} aria-label={title}>
         <PostTitle backgroundColour={randomColour1}>{title}</PostTitle>

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -6,6 +6,7 @@ import { PostHeaderProps } from '../lib/types';
 import styled from '@emotion/styled';
 import { colours } from '../pages/_app';
 import DOMPurify from 'isomorphic-dompurify';
+import { useMemo } from 'react';
 
 export default function PostHeader({
   title,
@@ -28,15 +29,16 @@ export default function PostHeader({
     colours.azure,
     colours.blueish,
   ];
-  const randomIndex1 = Math.floor(Math.random() * blockColours.length);
-  let randomIndex2 = Math.floor(Math.random() * blockColours.length);
 
-  while (randomIndex2 === randomIndex1) {
-    randomIndex2 = Math.floor(Math.random() * blockColours.length);
-  }
-
-  const randomColour1 = blockColours[randomIndex1];
-  const randomColour2 = blockColours[randomIndex2];
+  const { randomColour1, randomColour2 } = useMemo(() => {
+    const index1 = Math.floor(Math.random() * blockColours.length);
+    let index2 = Math.floor(Math.random() * blockColours.length);
+    while (index2 === index1) {
+      index2 = Math.floor(Math.random() * blockColours.length);
+    }
+    return { randomColour1: blockColours[index1], randomColour2: blockColours[index2] };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,8 +10,6 @@ import SearchBar from '../components/search-bar';
 import SearchResults from '../components/search-results';
 import { hardCodedListOfPostIds } from '../data/allIds';
 
-import { nanoid } from 'nanoid';
-
 export default function Index({
   preview,
   jamesImages,
@@ -331,7 +329,7 @@ export default function Index({
         {blocks.map((block) => (
           <HomepageBlock
             className={block.className}
-            key={nanoid()}
+            key={block.className}
             title={block.title}
             url={block.url}
             size={block.size}


### PR DESCRIPTION
## Summary

Wednesday performance optimisation pass. Three targeted fixes for re-render bugs found in the homepage and post header components.

### Changes

**1. `pages/index.tsx` — remove `nanoid()` as a React key**

`nanoid()` was used as the `key` prop for each `HomepageBlock` in the homepage grid. Because `nanoid()` generates a new random string on every call, React received a completely different key for every block on every render — causing it to **unmount and remount all 48+ blocks** whenever any state changed (e.g. the `setRandomImage` call inside `useEffect` on mount).

Fix: use `block.className` as the key. Every block already has a unique `className` (e.g. `block-1`, `block-2-1 placeholder`, etc.), making it a stable, correct key. The `nanoid` import is also removed as it is no longer needed anywhere in the file.

**2. `components/homepage-block.tsx` — stable colour via lazy `useState` initialiser**

The `randomColour` was previously set inside a `useEffect` triggered by `[title, size, image]` changes. This meant the block's background colour was **re-randomised every time a parent re-render propagated new prop values** — producing visible colour flickers on the homepage after hydration.

Fix: initialise `randomColour` with a lazy `useState` initialiser (`useState(() => blockColours[...])`) so the colour is chosen exactly once on mount and is never recalculated. The image-selection logic remains in the `useEffect` where it belongs. Additionally, `jamesImages` has been added to the effect's dependency array — it was used inside the effect but was missing from the deps list, which could cause stale-closure bugs in future.

**3. `components/post-header.tsx` — `useMemo` for random colour pair**

The two random accent colours used for the post title background and the posted-date bar were computed with bare `Math.random()` calls directly in the function body. This meant they were **recalculated on every render pass**, causing the header colours to change unexpectedly if a parent re-rendered.

Fix: wrap the computation in `useMemo` with an empty dependency array so the colour pair is chosen once per component instance and remains stable.

## Test plan

- [ ] Visit the homepage — confirm blocks render with consistent colours and do not flicker after the initial load
- [ ] Verify the homepage grid layout is unchanged
- [ ] Visit a blog post page — confirm title background and date bar colours are stable and do not change on interaction
- [ ] Check browser devtools React profiler: after initial mount, interactions (e.g. typing in the search bar) should not cause HomepageBlocks to unmount/remount

https://claude.ai/code/session_014KUoLfkepEGdcNs1gJwiSk