### PR TITLE
fix: use proper CSS media query strings for image sizes attributes

### DIFF
--- a/components/cover-image.tsx
+++ b/components/cover-image.tsx
@@ -25,7 +25,7 @@ export default function CoverImage({ title, coverImage, imageSize, slug, heroPos
     <Image
       alt={`Cover Image for ${title}`}
       src={coverImage?.node.sourceUrl}
-      sizes={imageSize || coverImage?.node.mediaDetails.srcset}
+      sizes={imageSize || '(max-width: 768px) 100vw, 50vw'}
       quality={75}
       fill
       loading={heroPost ? 'eager' : 'lazy'}

--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -92,6 +92,7 @@ export default function HomepageBlock({
               alt={title}
               width={230}
               height={230}
+              sizes="(max-width: 768px) 50vw, (max-width: 1200px) 15vw, 230px"
               quality={80}
               loading={eagerOrLazy()}
             />
@@ -103,6 +104,7 @@ export default function HomepageBlock({
               alt={title}
               width={474}
               height={474}
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 30vw, 474px"
               quality={80}
               loading={eagerOrLazy()}
             />
@@ -114,6 +116,7 @@ export default function HomepageBlock({
               alt={title}
               width={840}
               height={840}
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 840px"
               quality={80}
               loading={eagerOrLazy()}
             />
@@ -127,6 +130,7 @@ export default function HomepageBlock({
             alt={title}
             width={size === 1 ? 270 : 550}
             height={size === 1 ? 270 : 550}
+            sizes={size === 1 ? '(max-width: 768px) 50vw, (max-width: 1200px) 15vw, 270px' : '(max-width: 768px) 100vw, (max-width: 1200px) 30vw, 550px'}
             quality={80}
             loading={eagerOrLazy()}
           />

--- a/components/intro.tsx
+++ b/components/intro.tsx
@@ -64,7 +64,7 @@ export default function Intro({ jamesImages }: IntroProps) {
                         alt={jamesAltTag}
                         width={300}
                         height={300}
-                        sizes={jamesImage.srcset}
+                        sizes="(max-width: 768px) 12vw, 12vw"
                         quality={75}
                         loading="lazy"
                       />


### PR DESCRIPTION
## Summary
- `cover-image.tsx`: fallback `sizes` was set to `mediaDetails.srcset` (a srcset string) — replaced with `(max-width: 768px) 100vw, 50vw`
- `intro.tsx`: `sizes` was set to `jamesImage.srcset` — replaced with `(max-width: 768px) 12vw, 12vw` (images are 1/8 of viewport width in an 8-column grid)
- `homepage-block.tsx`: all image variants (size 1/2/3) were missing `sizes` entirely — added appropriate media query strings based on grid layout

Without correct `sizes` values, browsers can't determine the display size at each viewport, so they fall back to downloading full-size images on mobile.

## Test plan
- [x] Homepage loads and images render correctly on mobile and desktop
- [x] No layout shift visible on images in the intro grid and homepage blocks
- [ ] Browser DevTools Network tab shows smaller image variants being requested on narrower viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)