### PR TITLE
perf: fix CLS on post header and remove vanilla-lazyload

### DIFF
--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -1,30 +1,9 @@
 import { PostBodyProps } from '../lib/types';
 import styled from '@emotion/styled';
 import { colours } from '../pages/_app';
-import { useEffect } from 'react';
-import type { ILazyLoadInstance } from 'vanilla-lazyload';
 import DOMPurify from 'isomorphic-dompurify';
 
 export default function PostBody({ content }: PostBodyProps) {
-  useEffect(() => {
-    let lazyLoadInstance: ILazyLoadInstance | null = null;
-
-    (async () => {
-      const LazyLoadModule = await import('vanilla-lazyload');
-      const LazyLoad = (LazyLoadModule.default || LazyLoadModule) as any;
-      if (typeof LazyLoad === 'function') {
-        lazyLoadInstance = new LazyLoad({
-          elements_selector: '.lazyload',
-        });
-      }
-    })();
-
-    return () => {
-      if (lazyLoadInstance) {
-        lazyLoadInstance.destroy();
-      }
-    };
-  }, []);
   return (
     <ContentContainer>
       <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }} />

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -68,7 +68,8 @@ export default function PostHeader({
 const ImageContainer = styled.div<{ aspectRatio: number }>`
   position: relative;
   min-width: 100%;
-  aspect-ratio: ${(props) => props.aspectRatio};
+  aspect-ratio: ${(props) => props.aspectRatio || '16/9'};
+  min-height: 200px;
 
   img {
     display: block;

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "tsc-files": "1.1.4",
-    "typescript": "6.0.2",
-    "vanilla-lazyload": "19.1.3"
+    "typescript": "6.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6484,11 +6484,6 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-lazyload@19.1.3:
-  version "19.1.3"
-  resolved "https://registry.yarnpkg.com/vanilla-lazyload/-/vanilla-lazyload-19.1.3.tgz#80197e5193607d2137abd048aa766d29fa948ab4"
-  integrity sha512-bBMERPu2AFJc35krS+8BOhq++c6dRfL6q368lJPnkS5U92fRQagTR3FsNta69/GukfZzDwDEjD5M3U7VuSiCDw==
-
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"


### PR DESCRIPTION
## Summary
- **`post-header.tsx`**: `ImageContainer` now falls back to `aspect-ratio: 16/9` when image dimensions are missing (previously `aspect-ratio: 0` caused the container to collapse, creating layout shift). Also adds `min-height: 200px` as a safety net.
- **`post-body.tsx`**: Removed `vanilla-lazyload` entirely — it targeted `.lazyload` class elements but WordPress already renders images with native `loading="lazy"`. The async import added ~10KB of JS for no benefit.
- **`package.json` / `yarn.lock`**: `vanilla-lazyload` uninstalled.

## Test plan
- [x] Visit a blog post page and confirm the cover image area renders with correct dimensions on load (no layout jump)
- [x] Check a post with no cover image / missing image dimensions — container should still occupy space (16/9 fallback)
- [ ] Confirm images in post body still lazy-load as expected without the library
- [ ] Check bundle size in Network tab — JS payload for post pages should be ~10KB smaller

🤖 Generated with [Claude Code](https://claude.com/claude-code)