### PR TITLE
feat: add reading time estimate and related posts to blog

### DIFF
--- a/components/pre-post.tsx
+++ b/components/pre-post.tsx
@@ -1,10 +1,15 @@
 import { PrePostProps } from '../lib/types';
 import styled from '@emotion/styled';
+import { calculateReadingTime } from './utils';
 
-export default function PrePost({ tags, date }: PrePostProps) {
+export default function PrePost({ tags, date, content }: PrePostProps) {
   const years = new Date().getFullYear() - new Date(date).getFullYear();
+  const readingTime = content ? calculateReadingTime(content) : null;
   return (
     <>
+      {readingTime !== null && (
+        <StyledReadingTime>{readingTime} min read</StyledReadingTime>
+      )}
       {tags.edges.map((tag, index) => (
         <div key={index}>
           {tag.node.name.includes('ExiledToryRemainerScum') && (
@@ -23,6 +28,20 @@ export default function PrePost({ tags, date }: PrePostProps) {
     </>
   );
 }
+
+const StyledReadingTime = styled.p`
+  font-size: 0.85rem;
+  line-height: 1.5rem;
+  font-weight: 600;
+  margin: 0 5rem;
+  padding: 0.75rem 0 0;
+  color: #666;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  @media (max-width: 768px) {
+    margin: 0 1rem;
+  }
+`;
 
 const StyledNote = styled.p`
   font-size: 0.8rem;

--- a/components/related-posts.tsx
+++ b/components/related-posts.tsx
@@ -1,0 +1,118 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import styled from '@emotion/styled';
+import { RelatedPostsProps } from '../lib/types';
+import { colours } from '../pages/_app';
+import DateFormatter from './date';
+
+export default function RelatedPosts({ posts }: RelatedPostsProps) {
+  if (posts.length === 0) return null;
+
+  return (
+    <StyledSection>
+      <StyledHeading>You might also like</StyledHeading>
+      <StyledGrid>
+        {posts.map((post) => (
+          <StyledCard key={post.slug}>
+            {post.featuredImage?.node && (
+              <StyledImageWrapper>
+                <Link href={`/${post.slug}`}>
+                  <Image
+                    src={post.featuredImage.node.sourceUrl}
+                    alt={post.title}
+                    width={post.featuredImage.node.mediaDetails.width || 400}
+                    height={post.featuredImage.node.mediaDetails.height || 250}
+                    style={{ objectFit: 'cover', width: '100%', height: '180px' }}
+                  />
+                </Link>
+              </StyledImageWrapper>
+            )}
+            <StyledCardBody>
+              <StyledCardTitle>
+                <Link href={`/${post.slug}`}>{post.title}</Link>
+              </StyledCardTitle>
+              <StyledCardDate>
+                <DateFormatter dateString={post.date} />
+              </StyledCardDate>
+            </StyledCardBody>
+          </StyledCard>
+        ))}
+      </StyledGrid>
+    </StyledSection>
+  );
+}
+
+const StyledSection = styled.section`
+  max-width: 60rem;
+  margin: 3rem auto 0;
+  padding: 2rem 1rem;
+  border-top: 2px solid ${colours.dark};
+`;
+
+const StyledHeading = styled.h2`
+  font-family: 'Oswald', sans-serif;
+  font-size: 1.5rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  margin: 0 0 1.5rem;
+  color: ${colours.dark};
+`;
+
+const StyledGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const StyledCard = styled.article`
+  display: flex;
+  flex-direction: column;
+  background: #f9f9f9;
+  overflow: hidden;
+`;
+
+const StyledImageWrapper = styled.div`
+  overflow: hidden;
+
+  img {
+    transition: transform 0.3s ease;
+  }
+
+  &:hover img {
+    transform: scale(1.03);
+  }
+`;
+
+const StyledCardBody = styled.div`
+  padding: 0.75rem 1rem 1rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+`;
+
+const StyledCardTitle = styled.h3`
+  font-family: 'Oswald', sans-serif;
+  font-size: 1rem;
+  letter-spacing: 1px;
+  margin: 0;
+  line-height: 1.4;
+
+  a {
+    color: ${colours.dark};
+    text-decoration: none;
+
+    &:hover {
+      color: ${colours.pink};
+    }
+  }
+`;
+
+const StyledCardDate = styled.div`
+  font-size: 0.8rem;
+  color: #666;
+`;

--- a/components/utils.tsx
+++ b/components/utils.tsx
@@ -17,6 +17,12 @@ export const getMonthNumber = (monthName: string) => {
   return monthNames.indexOf(monthName) + 1;
 };
 
+export const calculateReadingTime = (htmlContent: string): number => {
+  const text = htmlContent.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+  const wordCount = text.split(' ').filter((word) => word.length > 0).length;
+  return Math.max(1, Math.ceil(wordCount / 200));
+};
+
 export const getMonthName = (monthNumber: number) => {
   const monthNames = [
     'January',

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -425,6 +425,38 @@ export async function getPostsByTag(tag: string) {
   return data.posts.nodes;
 }
 
+export async function getRelatedPosts(tag: string, excludeSlug: string) {
+  const data = await fetchAPI(
+    `
+    query GetRelatedPosts($tag: String!) {
+      posts(where: { tag: $tag }, first: 4) {
+        nodes {
+          title
+          slug
+          date
+          excerpt
+          featuredImage {
+            node {
+              sourceUrl
+              mediaDetails {
+                height
+                width
+              }
+              srcSet
+            }
+          }
+        }
+      }
+    }`,
+    {
+      variables: { tag },
+    },
+  );
+  return (data.posts.nodes as { slug: string }[])
+    .filter((post) => post.slug !== excludeSlug)
+    .slice(0, 3);
+}
+
 export async function getRandomImage(randomMonth: number, randomYear: number) {
   const data = await fetchAPI(
     `

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,6 +61,7 @@ export type PostProps = {
     }[];
   };
   preview: string;
+  relatedPosts: RelatedPost[];
 };
 
 export type TagsPostProps = {
@@ -236,6 +237,7 @@ export type IndexPageProps = {
 
 export type PrePostProps = {
   date: string;
+  content?: string;
   tags: {
     edges: {
       node: {
@@ -410,6 +412,27 @@ export type seoProps = {
   opengraphTitle: string;
   opengraphSiteName: string;
   metaKeywords?: string;
+};
+
+export type RelatedPost = {
+  title: string;
+  slug: string;
+  date: string;
+  excerpt: string;
+  featuredImage: {
+    node: {
+      sourceUrl: string;
+      mediaDetails: {
+        height: number;
+        width: number;
+      };
+      srcSet: string;
+    };
+  } | null;
+};
+
+export type RelatedPostsProps = {
+  posts: RelatedPost[];
 };
 
 export type SearchBarProps = {

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -8,12 +8,13 @@ import SectionSeparator from '../components/section-separator';
 import Layout from '../components/layout';
 import PostTitle from '../components/post-title';
 import Tags from '../components/tags';
-import { getAllPostsWithSlug, getPost } from '../lib/api';
+import { getAllPostsWithSlug, getPost, getRelatedPosts } from '../lib/api';
 import { PostProps } from '../lib/types';
 import PrePost from '../components/pre-post';
+import RelatedPosts from '../components/related-posts';
 import Custom404 from './404';
 
-export default function Post({ post, preview }: PostProps) {
+export default function Post({ post, preview, relatedPosts }: PostProps) {
   const router = useRouter();
 
   if (!router.isFallback && !post?.slug) {
@@ -47,10 +48,11 @@ export default function Post({ post, preview }: PostProps) {
                   caption={post.featuredImage.node.caption}
                 />
               )}
-              <PrePost tags={post.tags} date={post.date} />
+              <PrePost tags={post.tags} date={post.date} content={post.content} />
               <PostBody content={post.content} />
               {post.tags.edges.length > 0 && <Tags tags={post.tags} />}
             </article>
+            {relatedPosts?.length > 0 && <RelatedPosts posts={relatedPosts} />}
             <SectionSeparator />
           </>
         )}
@@ -68,9 +70,13 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
   const data = await getPost(slug);
 
+  const firstTag = data?.tags?.edges?.[0]?.node?.name;
+  const relatedPosts = firstTag ? await getRelatedPosts(firstTag, slug) : [];
+
   return {
     props: {
       post: data,
+      relatedPosts,
     },
     revalidate: 3600,
   };


### PR DESCRIPTION
## Summary

- **Reading time estimate**: Each blog post now shows a "X min read" label above the content, calculated by stripping HTML from the post body and dividing word count by 200 WPM. Displayed in `PrePost` using a new `calculateReadingTime()` utility.
- **Related posts section**: After reading a post, up to 3 posts sharing the same primary tag are surfaced in a responsive card grid. Cards show the featured image, title, and date, and link to the related post. Falls back gracefully if no tag or no related posts exist.

## Changed files

| File | Change |
|---|---|
| `components/utils.tsx` | New `calculateReadingTime(html)` utility |
| `components/pre-post.tsx` | Accept optional `content` prop; render reading time label |
| `lib/api.ts` | New `getRelatedPosts(tag, excludeSlug)` GraphQL query (fetches 4, excludes current, returns 3) |
| `lib/types.ts` | New `RelatedPost` and `RelatedPostsProps` types; `PrePostProps` gains optional `content`; `PostProps` gains `relatedPosts` |
| `components/related-posts.tsx` | New component — responsive 3-column card grid (1 column on mobile) |
| `pages/[slug].tsx` | Pass `content` to `PrePost`; fetch related posts in `getStaticProps`; render `RelatedPosts` below article |

## Test plan

- [x] Open any blog post — "X min read" appears above the post body
- [x] Long posts show a higher read time than short ones
- [ ] At the bottom of a post with tags, a "You might also like" grid of up to 3 cards appears
- [ ] Each card links to its respective post
- [ ] A post with no tags shows no related posts section (no empty section rendered)
- [ ] On mobile, cards stack into a single column
- [ ] TypeScript: `npx tsc --noEmit` reports no new errors

https://claude.ai/code/session_0189kkdp8yd36xS83GBvwUDL