### PR TITLE
fix(a11y/seo): add missing OG metadata to 16 pages and fix nav ARIA attributes

### DIFF
--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -68,8 +68,12 @@ export default function Meta({ seo, title, ogType = 'article', articleDate, arti
         property="og:image"
         content={opengraphImage?.mediaItemUrl ? opengraphImage?.mediaItemUrl : defaultImageUrl}
       />
-      <meta property="og:image:width" content={opengraphImage?.mediaDetails?.width} />
-      <meta property="og:image:height" content={opengraphImage?.mediaDetails?.height} />
+      {opengraphImage?.mediaDetails?.width && (
+        <meta property="og:image:width" content={opengraphImage.mediaDetails.width} />
+      )}
+      {opengraphImage?.mediaDetails?.height && (
+        <meta property="og:image:height" content={opengraphImage.mediaDetails.height} />
+      )}
       {opengraphImage?.altText && <meta property="og:image:alt" content={opengraphImage.altText} />}
       {ogType === 'article' && articleDate && (
         <meta property="article:published_time" content={articleDate} />

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -47,7 +47,7 @@ export default function Nav() {
 
   return (
     <StyledNav>
-      <BurgerButton onClick={toggleDropdown}>
+      <BurgerButton onClick={toggleDropdown} aria-label="Open navigation menu" aria-expanded={isDropdownOpen}>
         <span></span>
         <span></span>
         <span></span>

--- a/pages/countries-visited.tsx
+++ b/pages/countries-visited.tsx
@@ -96,9 +96,14 @@ export default function CountriesVisited({
   };
 }) {
   const router = useRouter();
+  const seo = {
+    opengraphTitle: 'Countries Visited | World Of Winfield',
+    opengraphDescription: 'Countries visited by James Winfield, organised by continent.',
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   return (
-    <Layout preview={null} title="Countries Visited">
+    <Layout preview={null} title="Countries Visited" seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-articles.tsx
+++ b/pages/favourite-articles.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Articles Read';
   const sheetId = '1R928oTM4hiTFXZ6Ww9-2pMKLAWy2Wjf3Z9xrXC6GTa0';
+  const seo = {
+    opengraphTitle: 'Favourite Articles | World Of Winfield',
+    opengraphDescription: "A curated list of James Winfield's favourite articles read.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-beers.tsx
+++ b/pages/favourite-beers.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Beer';
   const sheetId = '1pNNIw849xWrQHtDptwInGs6Un0AZh-fgXUssC3XIrHM';
+  const seo = {
+    opengraphTitle: 'Favourite Beers | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite beers.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-books.tsx
+++ b/pages/favourite-books.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Books';
   const sheetId = '1G-QrN1NDpKAr12VyIi50Nod8_g-YOSGP3bovCXxDHlY';
+  const seo = {
+    opengraphTitle: 'Favourite Books | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite books.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-cheese.tsx
+++ b/pages/favourite-cheese.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Cheese';
   const sheetId = '1UDjT7_Q5rBPQasn4o2qxUOsEcElEI67nl-ep9YTLc-E';
+  const seo = {
+    opengraphTitle: 'Favourite Cheese | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite cheeses.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-cities.tsx
+++ b/pages/favourite-cities.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Cities Visited';
   const sheetId = '1WBfOTfhC70AygxrTcIIgvigzlvOD65WfI9Ysrd3aF5o';
+  const seo = {
+    opengraphTitle: 'Favourite Cities Visited | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite cities visited.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-countries.tsx
+++ b/pages/favourite-countries.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Countries Visited';
   const sheetId = '1zyzuLzWY0S6mUp-FVjcIa3QFAENcU94WVD9ZF0JWERY';
+  const seo = {
+    opengraphTitle: 'Favourite Countries Visited | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite countries visited.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-djs.tsx
+++ b/pages/favourite-djs.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite DJs';
   const sheetId = '1_zpDBFlpW2ZWTVsXQHoW6Y4FbGw8Vi53nMYpZiOypbg';
+  const seo = {
+    opengraphTitle: 'Favourite DJs | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite DJs.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-movies.tsx
+++ b/pages/favourite-movies.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Movies';
   const sheetId = '1q3LFzLYqK0tLWHjvHYxFE1IIF-FrOJuqJ6XBIQIEl6U';
+  const seo = {
+    opengraphTitle: 'Favourite Movies | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite movies.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-restaurants.tsx
+++ b/pages/favourite-restaurants.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Restaurants';
   const sheetId = '1J1znKQxeNR3Y6Q1mEPzZyMfCAGK4FQyxasoCQx35NVQ';
+  const seo = {
+    opengraphTitle: 'Favourite Restaurants | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite restaurants.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/favourite-tracks.tsx
+++ b/pages/favourite-tracks.tsx
@@ -14,6 +14,11 @@ export default function FavouritesPage() {
   const columnsToHide = ['Date Added'];
   const indexRequired = false;
   const sortBy = 'Artist/Track Name';
+  const seo = {
+    opengraphTitle: 'Favourite Tracks | World Of Winfield',
+    opengraphDescription: "A ranked list of James Winfield's favourite music tracks.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
   const [selectedGenre, setSelectedGenre] = useState('');
@@ -47,7 +52,7 @@ export default function FavouritesPage() {
   }, [sheetId]);
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/holiday-wish-list.tsx
+++ b/pages/holiday-wish-list.tsx
@@ -11,12 +11,17 @@ import { useState } from 'react';
 export default function WishListPage() {
   const title = 'Holiday Wish List';
   const sheetId = '1GX6KF20f3Nrb3m8T9th7UIV_uuePj4Ivlc_yLgo-4Bo';
+  const seo = {
+    opengraphTitle: 'Holiday Wish List | World Of Winfield',
+    opengraphDescription: "James Winfield's holiday wish list — places around the world still to visit.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
   const [selectedSort, setSelectedSort] = useState('');
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/now.tsx
+++ b/pages/now.tsx
@@ -4,8 +4,15 @@ import Layout from '../components/layout';
 import styled from '@emotion/styled';
 
 export default function NowPage() {
+  const seo = {
+    opengraphTitle: 'Now | World Of Winfield',
+    opengraphDescription:
+      "What James Winfield is up to right now — current location, projects, and interests.",
+    opengraphSiteName: 'World Of Winfield',
+  };
+
   return (
-    <Layout preview={null} title="Now">
+    <Layout preview={null} title="Now" seo={seo}>
       <Container>
         <PostContainer>
           <StyledPostHeader>

--- a/pages/restaurant-wish-list.tsx
+++ b/pages/restaurant-wish-list.tsx
@@ -9,11 +9,16 @@ import FavouriteResults from './favourites-results';
 export default function WishListPage() {
   const title = 'Restaurant Wish List';
   const sheetId = '13gz7lPQ61f_WKQ_xio_QBlUcFB9Dl0yVBynwEadVO_4';
+  const seo = {
+    opengraphTitle: 'Restaurant Wish List | World Of Winfield',
+    opengraphDescription: "James Winfield's restaurant wish list — restaurants he still wants to try.",
+    opengraphSiteName: 'World Of Winfield',
+  };
 
   const router = useRouter();
 
   return (
-    <Layout preview={null} title={title}>
+    <Layout preview={null} title={title} seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/stocks.tsx
+++ b/pages/stocks.tsx
@@ -532,8 +532,14 @@ export default function StocksPage() {
     };
   }, [wsUrl]);
 
+  const seo = {
+    opengraphTitle: 'Stocks | World Of Winfield',
+    opengraphDescription: 'Live stock market tracking and portfolio overview by James Winfield.',
+    opengraphSiteName: 'World Of Winfield',
+  };
+
   return (
-    <Layout preview={null} title="Stocks">
+    <Layout preview={null} title="Stocks" seo={seo}>
       <Container>
         <PostHeader title="Stocks" />
 

--- a/pages/wants.tsx
+++ b/pages/wants.tsx
@@ -17,8 +17,14 @@ export default function WantsPage() {
 
   const router = useRouter();
 
+  const seo = {
+    opengraphTitle: 'Wants | World Of Winfield',
+    opengraphDescription: "James Winfield's wish lists — places to visit and restaurants to try.",
+    opengraphSiteName: 'World Of Winfield',
+  };
+
   return (
-    <Layout preview={null} title="Posts About Wants">
+    <Layout preview={null} title="Posts About Wants" seo={seo}>
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>


### PR DESCRIPTION
## Summary

Today's focus (Saturday → most impactful category review) identified **Accessibility & SEO** as the highest-impact area. 16 pages were serving the generic fallback metadata for every social share, and the mobile nav burger button was invisible to screen readers.

### Changes

**`components/meta.tsx`**
- `og:image:width` and `og:image:height` were always emitted even when no image was provided, resulting in `<meta content="undefined">` tags in the HTML. These are now rendered conditionally.

**`components/nav.tsx`**
- The burger/hamburger button (`<BurgerButton>`) had no accessible label and no state announcement. Added `aria-label="Open navigation menu"` and `aria-expanded={isDropdownOpen}` so screen readers announce both the button's purpose and whether the menu is currently open or closed.

**16 pages — static `seo` prop added**

Each of the following pages was passing only a bare `title` to `<Layout>`, so every social share fell back to "World Of Winfield - all about James Winfield" for both title and description. Each page now passes a page-specific `opengraphTitle`, `opengraphDescription`, and `opengraphSiteName`:

| Page | OG title |
|---|---|
| `favourite-countries` | Favourite Countries Visited \| World Of Winfield |
| `favourite-cities` | Favourite Cities Visited \| World Of Winfield |
| `favourite-movies` | Favourite Movies \| World Of Winfield |
| `favourite-books` | Favourite Books \| World Of Winfield |
| `favourite-beers` | Favourite Beers \| World Of Winfield |
| `favourite-djs` | Favourite DJs \| World Of Winfield |
| `favourite-restaurants` | Favourite Restaurants \| World Of Winfield |
| `favourite-cheese` | Favourite Cheese \| World Of Winfield |
| `favourite-tracks` | Favourite Tracks \| World Of Winfield |
| `favourite-articles` | Favourite Articles \| World Of Winfield |
| `wants` | Wants \| World Of Winfield |
| `holiday-wish-list` | Holiday Wish List \| World Of Winfield |
| `restaurant-wish-list` | Restaurant Wish List \| World Of Winfield |
| `countries-visited` | Countries Visited \| World Of Winfield |
| `now` | Now \| World Of Winfield |
| `stocks` | Stocks \| World Of Winfield |

## Test plan

- [ ] Share a favourite page URL (e.g. `/favourite-movies`) on a social platform or paste into the Twitter card validator — confirm the page-specific title and description appear
- [ ] View source on any updated page and confirm no `<meta content="undefined">` tags are present
- [ ] On mobile (≤768 px), open browser devtools accessibility tree and confirm the burger button shows label "Open navigation menu" and `expanded: false` / `expanded: true` as the menu toggles
- [ ] Run existing test suite (`yarn test`) — no regressions expected

https://claude.ai/code/session_015oYne29tMUDwsn27PdUQVG