### PR TITLE
a11y: fix critical accessibility issues

### DIFF
--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -145,8 +145,8 @@ export default function HomepageBlock({
       size={size}
       image={imageSrc}
       date={date}>
-      <StyledIconLinkBlock href={url ?? '/'}>
-        <p aria-label={title}>{title}</p>
+      <StyledIconLinkBlock href={url ?? '/'} aria-label={title}>
+        <p>{title}</p>
         <StyledIcon>
           <Image src={`/icons/${icon}.png`} alt="" width={64} height={64} />
         </StyledIcon>

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -47,7 +47,7 @@ export default function Nav() {
 
   return (
     <StyledNav>
-      <BurgerButton onClick={toggleDropdown}>
+      <BurgerButton onClick={toggleDropdown} aria-label="Toggle navigation menu" aria-expanded={isDropdownOpen}>
         <span></span>
         <span></span>
         <span></span>
@@ -82,7 +82,9 @@ export default function Nav() {
                   e.preventDefault();
                   e.stopPropagation();
                   toggleFavouritesDropdown();
-                }}>
+                }}
+                aria-label="Toggle Favourites submenu"
+                aria-expanded={isFavouritesDropdownOpen}>
                 ▼
               </DropdownArrow>
             </SplitButtonContainer>
@@ -159,7 +161,9 @@ export default function Nav() {
                   e.preventDefault();
                   e.stopPropagation();
                   toggleWishListDropdown();
-                }}>
+                }}
+                aria-label="Toggle Wish Lists submenu"
+                aria-expanded={isWishListDropdownOpen}>
                 ▼
               </DropdownArrow>
             </SplitButtonContainer>
@@ -198,7 +202,9 @@ export default function Nav() {
                   e.preventDefault();
                   e.stopPropagation();
                   toggleTravelDropdown();
-                }}>
+                }}
+                aria-label="Toggle Travel submenu"
+                aria-expanded={isTravelDropdownOpen}>
                 ▼
               </DropdownArrow>
             </SplitButtonContainer>
@@ -256,9 +262,14 @@ const NavList = styled.ul`
   padding: 1rem;
   @media (max-width: 768px) {
     padding: 0.5rem;
-    display: none;
+    visibility: hidden;
+    height: 0;
+    overflow: hidden;
 
     &.open {
+      visibility: visible;
+      height: auto;
+      overflow: visible;
       display: flex;
       flex-direction: column;
       align-items: center;


### PR DESCRIPTION
## Summary

- Add `aria-label` and `aria-expanded` to the burger menu button so screen readers can identify and announce its state
- Add `aria-label` and `aria-expanded` to all three dropdown arrow buttons (Favourites, Wish Lists, Travel)
- Move `aria-label` from inner `<p>` to the `<Link>` on icon-only homepage blocks so the link itself has an accessible name
- Replace `display:none` with `visibility: hidden` + `height: 0` on mobile nav so assistive technologies handle visibility correctly

## Test plan

- [x] Tab to burger menu on mobile viewport — screen reader should announce "Toggle navigation menu" and expanded state
- [x] Tab to each dropdown arrow — should announce the submenu name and expanded state
- [ ] Verify icon blocks on homepage are announced with their title text
- [ ] Verify mobile nav opens/closes correctly visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)