### PR TITLE
test: add unit tests for 10 previously untested components

### DIFF
--- a/components/GenreDropdown.test.tsx
+++ b/components/GenreDropdown.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GenreDropdown from './GenreDropdown';
+
+const genres = ['Rock', 'Pop', 'Jazz', 'Classical'];
+
+describe('GenreDropdown', () => {
+  it('renders the "Filter by genre:" label', () => {
+    render(<GenreDropdown genres={genres} selectedGenre="" onChange={jest.fn()} />);
+    expect(screen.getByText('Filter by genre:')).toBeInTheDocument();
+  });
+
+  it('renders the "All Genres" default option', () => {
+    render(<GenreDropdown genres={genres} selectedGenre="" onChange={jest.fn()} />);
+    expect(screen.getByRole('option', { name: 'All Genres' })).toBeInTheDocument();
+  });
+
+  it('renders all provided genre options', () => {
+    render(<GenreDropdown genres={genres} selectedGenre="" onChange={jest.fn()} />);
+    genres.forEach((genre) => {
+      expect(screen.getByRole('option', { name: genre })).toBeInTheDocument();
+    });
+  });
+
+  it('reflects the selected genre via the select value', () => {
+    render(<GenreDropdown genres={genres} selectedGenre="Rock" onChange={jest.fn()} />);
+    expect(screen.getByRole('combobox')).toHaveValue('Rock');
+  });
+
+  it('calls onChange with the chosen genre when the selection changes', () => {
+    const handleChange = jest.fn();
+    render(<GenreDropdown genres={genres} selectedGenre="" onChange={handleChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Jazz' } });
+    expect(handleChange).toHaveBeenCalledWith('Jazz');
+  });
+
+  it('calls onChange with an empty string when "All Genres" is selected', () => {
+    const handleChange = jest.fn();
+    render(<GenreDropdown genres={genres} selectedGenre="Rock" onChange={handleChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } });
+    expect(handleChange).toHaveBeenCalledWith('');
+  });
+
+  it('renders correctly with an empty genres list', () => {
+    render(<GenreDropdown genres={[]} selectedGenre="" onChange={jest.fn()} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'All Genres' })).toBeInTheDocument();
+  });
+});

--- a/components/SortDropdown.test.tsx
+++ b/components/SortDropdown.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SortDropdown from './SortDropdown';
+
+const options = ['Name A-Z', 'Name Z-A', 'Date: Newest', 'Date: Oldest'];
+
+describe('SortDropdown', () => {
+  it('renders the "Sort by:" label', () => {
+    render(<SortDropdown options={options} selected="" onChange={jest.fn()} />);
+    expect(screen.getByText('Sort by:')).toBeInTheDocument();
+  });
+
+  it('renders the "Default" default option', () => {
+    render(<SortDropdown options={options} selected="" onChange={jest.fn()} />);
+    expect(screen.getByRole('option', { name: 'Default' })).toBeInTheDocument();
+  });
+
+  it('renders all provided sort options', () => {
+    render(<SortDropdown options={options} selected="" onChange={jest.fn()} />);
+    options.forEach((option) => {
+      expect(screen.getByRole('option', { name: option })).toBeInTheDocument();
+    });
+  });
+
+  it('reflects the selected option via the select value', () => {
+    render(<SortDropdown options={options} selected="Name A-Z" onChange={jest.fn()} />);
+    expect(screen.getByRole('combobox')).toHaveValue('Name A-Z');
+  });
+
+  it('calls onChange with the chosen value when the selection changes', () => {
+    const handleChange = jest.fn();
+    render(<SortDropdown options={options} selected="" onChange={handleChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Date: Newest' } });
+    expect(handleChange).toHaveBeenCalledWith('Date: Newest');
+  });
+
+  it('calls onChange with an empty string when "Default" is selected', () => {
+    const handleChange = jest.fn();
+    render(<SortDropdown options={options} selected="Name A-Z" onChange={handleChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } });
+    expect(handleChange).toHaveBeenCalledWith('');
+  });
+
+  it('renders correctly with an empty options list', () => {
+    render(<SortDropdown options={[]} selected="" onChange={jest.fn()} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Default' })).toBeInTheDocument();
+  });
+});

--- a/components/container.test.tsx
+++ b/components/container.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Container from './container';
+
+describe('Container', () => {
+  it('renders its children', () => {
+    render(
+      <Container>
+        <p>Child content</p>
+      </Container>
+    );
+    expect(screen.getByText('Child content')).toBeInTheDocument();
+  });
+
+  it('renders multiple children', () => {
+    render(
+      <Container>
+        <p>First child</p>
+        <p>Second child</p>
+      </Container>
+    );
+    expect(screen.getByText('First child')).toBeInTheDocument();
+    expect(screen.getByText('Second child')).toBeInTheDocument();
+  });
+});

--- a/components/cover-image.test.tsx
+++ b/components/cover-image.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CoverImage from './cover-image';
+
+const coverImageData = {
+  node: {
+    sourceUrl: 'https://example.com/image.jpg',
+    mediaDetails: {
+      width: 800,
+      height: 600,
+      sizes: '(max-width: 768px) 100vw, 50vw',
+      srcset: 'https://example.com/image-400.jpg 400w',
+    },
+  },
+};
+
+describe('CoverImage', () => {
+  it('renders no image when coverImage is not provided', () => {
+    render(<CoverImage title="Test Post" />);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('renders an image when coverImage with a sourceUrl is provided', () => {
+    render(<CoverImage title="Test Post" coverImage={coverImageData} />);
+    expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  it('sets the alt text to include the post title', () => {
+    render(<CoverImage title="My Post Title" coverImage={coverImageData} />);
+    expect(screen.getByAltText('Cover Image for My Post Title')).toBeInTheDocument();
+  });
+
+  it('wraps the image in a link to the post when slug is provided', () => {
+    render(<CoverImage title="Test Post" coverImage={coverImageData} slug="test-post" />);
+    const link = screen.getByRole('link', { name: 'Test Post' });
+    expect(link).toHaveAttribute('href', '/test-post');
+  });
+
+  it('does not render a link when no slug is provided', () => {
+    render(<CoverImage title="Test Post" coverImage={coverImageData} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('loads the image eagerly when heroPost is true', () => {
+    render(<CoverImage title="Test Post" coverImage={coverImageData} heroPost />);
+    expect(screen.getByRole('img')).toHaveAttribute('loading', 'eager');
+  });
+
+  it('loads the image lazily by default', () => {
+    render(<CoverImage title="Test Post" coverImage={coverImageData} />);
+    expect(screen.getByRole('img')).toHaveAttribute('loading', 'lazy');
+  });
+});

--- a/components/hero-post.test.tsx
+++ b/components/hero-post.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HeroPost from './hero-post';
+import { HeroPostProps } from '../lib/types';
+
+jest.mock('isomorphic-dompurify', () => ({
+  __esModule: true,
+  default: { sanitize: (html: string) => html },
+}));
+
+jest.mock('./post-header', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="post-header">{title}</div>,
+}));
+
+jest.mock('./core-components', () => ({
+  StyledButton: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const baseProps: HeroPostProps = {
+  title: 'Hero Post Title',
+  date: '2023-01-15',
+  excerpt: '<p>This is the excerpt.</p>',
+  slug: 'hero-post-slug',
+  author: {
+    node: {
+      name: 'James Winfield',
+      firstName: 'James',
+      lastName: 'Winfield',
+      avatar: { url: '' },
+      description: '',
+    },
+  },
+  featuredImage: {
+    node: {
+      sourceUrl: 'https://example.com/image.jpg',
+      mediaDetails: { height: 600, width: 800, sizes: '', srcset: '' },
+      caption: '',
+    },
+  },
+};
+
+describe('HeroPost', () => {
+  it('renders the PostHeader', () => {
+    render(<HeroPost {...baseProps} />);
+    expect(screen.getByTestId('post-header')).toBeInTheDocument();
+  });
+
+  it('passes the title to PostHeader', () => {
+    render(<HeroPost {...baseProps} />);
+    expect(screen.getByTestId('post-header')).toHaveTextContent('Hero Post Title');
+  });
+
+  it('renders a "Read More" link', () => {
+    render(<HeroPost {...baseProps} />);
+    expect(screen.getByRole('link', { name: 'Read More' })).toBeInTheDocument();
+  });
+
+  it('"Read More" link points to the post slug', () => {
+    render(<HeroPost {...baseProps} />);
+    expect(screen.getByRole('link', { name: 'Read More' })).toHaveAttribute(
+      'href',
+      'hero-post-slug'
+    );
+  });
+
+  it('renders the excerpt text', () => {
+    render(<HeroPost {...baseProps} excerpt="<p>My interesting excerpt.</p>" />);
+    expect(screen.getByText('My interesting excerpt.')).toBeInTheDocument();
+  });
+
+  it('strips external anchor links from the excerpt', () => {
+    const excerptWithLink =
+      '<p>Some text. <a href="https://external.com">External Link</a></p>';
+    render(<HeroPost {...baseProps} excerpt={excerptWithLink} />);
+    expect(screen.queryByText('External Link')).not.toBeInTheDocument();
+    expect(screen.getByText(/Some text\./)).toBeInTheDocument();
+  });
+
+  it('preserves non-external-link text after stripping', () => {
+    const excerptWithLink =
+      '<p>Intro. <a href="https://example.com">Click here</a> Conclusion.</p>';
+    render(<HeroPost {...baseProps} excerpt={excerptWithLink} />);
+    expect(screen.queryByText('Click here')).not.toBeInTheDocument();
+    expect(screen.getByText(/Intro\./)).toBeInTheDocument();
+  });
+});

--- a/components/layout.test.tsx
+++ b/components/layout.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Layout from './layout';
+
+jest.mock('./alert', () => ({
+  __esModule: true,
+  default: ({ preview }: { preview: string | null }) =>
+    preview ? <div data-testid="alert">Preview Mode</div> : null,
+}));
+
+jest.mock('./meta', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./footer', () => ({
+  __esModule: true,
+  default: () => <footer data-testid="footer">Footer</footer>,
+}));
+
+describe('Layout', () => {
+  it('renders children inside the main element', () => {
+    render(
+      <Layout preview={null}>
+        <p>Page content</p>
+      </Layout>
+    );
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+  });
+
+  it('renders the skip-to-main-content link', () => {
+    render(
+      <Layout preview={null}>
+        <p>Content</p>
+      </Layout>
+    );
+    const skipLink = screen.getByText('Skip to main content');
+    expect(skipLink).toBeInTheDocument();
+    expect(skipLink).toHaveAttribute('href', '#main-content');
+  });
+
+  it('gives the main element the id "main-content" for the skip link to target', () => {
+    render(
+      <Layout preview={null}>
+        <p>Content</p>
+      </Layout>
+    );
+    expect(screen.getByRole('main')).toHaveAttribute('id', 'main-content');
+  });
+
+  it('renders the footer', () => {
+    render(
+      <Layout preview={null}>
+        <p>Content</p>
+      </Layout>
+    );
+    expect(screen.getByTestId('footer')).toBeInTheDocument();
+  });
+
+  it('renders the alert banner when in preview mode', () => {
+    render(
+      <Layout preview="true">
+        <p>Content</p>
+      </Layout>
+    );
+    expect(screen.getByTestId('alert')).toBeInTheDocument();
+  });
+
+  it('does not render the alert banner outside preview mode', () => {
+    render(
+      <Layout preview={null}>
+        <p>Content</p>
+      </Layout>
+    );
+    expect(screen.queryByTestId('alert')).not.toBeInTheDocument();
+  });
+});

--- a/components/more-stories.test.tsx
+++ b/components/more-stories.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MoreStories from './more-stories';
+import { MoreStoriesProps } from '../lib/types';
+
+jest.mock('./post-preview', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="post-preview">{title}</div>,
+}));
+
+const author = {
+  node: {
+    name: 'James Winfield',
+    firstName: 'James',
+    lastName: 'Winfield',
+    avatar: { url: '' },
+    description: '',
+  },
+};
+
+const makeFeaturedImage = (url: string) => ({
+  node: {
+    sourceUrl: url,
+    mediaDetails: { height: 100, width: 100, sizes: '', srcset: '' },
+    caption: '',
+  },
+});
+
+const mockPosts: MoreStoriesProps['posts'] = [
+  {
+    node: {
+      slug: 'first-post',
+      title: 'First Post',
+      featuredImage: makeFeaturedImage('https://example.com/image1.jpg'),
+      date: '2023-01-15',
+      author,
+      content: '<p>Content 1</p>',
+      excerpt: '<p>Excerpt 1</p>',
+    },
+  },
+  {
+    node: {
+      slug: 'second-post',
+      title: 'Second Post',
+      featuredImage: makeFeaturedImage('https://example.com/image2.jpg'),
+      date: '2023-02-20',
+      author,
+      content: '<p>Content 2</p>',
+      excerpt: '<p>Excerpt 2</p>',
+    },
+  },
+];
+
+describe('MoreStories', () => {
+  it('renders one PostPreview per post', () => {
+    render(<MoreStories posts={mockPosts} />);
+    expect(screen.getAllByTestId('post-preview')).toHaveLength(2);
+  });
+
+  it('passes the post title to each PostPreview', () => {
+    render(<MoreStories posts={mockPosts} />);
+    expect(screen.getByText('First Post')).toBeInTheDocument();
+    expect(screen.getByText('Second Post')).toBeInTheDocument();
+  });
+
+  it('renders no PostPreviews when posts is empty', () => {
+    render(<MoreStories posts={[]} />);
+    expect(screen.queryByTestId('post-preview')).not.toBeInTheDocument();
+  });
+});

--- a/components/post-body.test.tsx
+++ b/components/post-body.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PostBody from './post-body';
+import DOMPurify from 'isomorphic-dompurify';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+jest.mock('isomorphic-dompurify', () => ({
+  __esModule: true,
+  default: {
+    sanitize: jest.fn((html: string) => html),
+    addHook: jest.fn(),
+    removeHook: jest.fn(),
+  },
+}));
+
+describe('PostBody', () => {
+  it('renders provided HTML content', () => {
+    render(<PostBody content="<p>Hello world</p>" />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('renders multiple HTML elements from the content', () => {
+    render(<PostBody content="<h1>Heading</h1><p>Paragraph</p>" />);
+    expect(screen.getByText('Heading')).toBeInTheDocument();
+    expect(screen.getByText('Paragraph')).toBeInTheDocument();
+  });
+
+  it('renders without crashing for empty content', () => {
+    const { container } = render(<PostBody content="" />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('passes content through DOMPurify.sanitize with extended attributes', () => {
+    render(<PostBody content="<p>Test content</p>" />);
+    expect(DOMPurify.sanitize).toHaveBeenCalledWith(
+      '<p>Test content</p>',
+      expect.objectContaining({ ADD_ATTR: expect.arrayContaining(['srcset']) })
+    );
+  });
+});

--- a/components/post-header.test.tsx
+++ b/components/post-header.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PostHeader from './post-header';
+
+jest.mock('isomorphic-dompurify', () => ({
+  __esModule: true,
+  default: { sanitize: (html: string) => html },
+}));
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+jest.mock('./date', () => ({
+  __esModule: true,
+  default: ({ dateString }: { dateString: string }) => (
+    <time dateTime={dateString}>{dateString}</time>
+  ),
+}));
+
+jest.mock('./cover-image', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => (
+    <div data-testid="cover-image" aria-label={title} />
+  ),
+}));
+
+jest.mock('./post-title', () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => <h1>{children}</h1>,
+}));
+
+const baseProps = {
+  title: 'My Post Title',
+  slug: 'my-post',
+  date: '2023-01-15',
+};
+
+describe('PostHeader', () => {
+  it('renders the post title as a link to the slug', () => {
+    render(<PostHeader {...baseProps} />);
+    const link = screen.getByRole('link', { name: 'My Post Title' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/my-post');
+  });
+
+  it('renders a "Posted" label and the date when date is provided', () => {
+    render(<PostHeader {...baseProps} />);
+    expect(screen.getByText(/Posted/)).toBeInTheDocument();
+    expect(screen.getByText('2023-01-15')).toBeInTheDocument();
+  });
+
+  it('does not render the date section when date is omitted', () => {
+    render(<PostHeader title="My Post" slug="my-post" />);
+    expect(screen.queryByText(/Posted/)).not.toBeInTheDocument();
+  });
+
+  it('renders the cover image when provided', () => {
+    const coverImage = {
+      node: {
+        sourceUrl: 'https://example.com/image.jpg',
+        mediaDetails: { width: 800, height: 600, sizes: '', srcset: '' },
+        caption: '',
+      },
+    };
+    render(<PostHeader {...baseProps} coverImage={coverImage} />);
+    expect(screen.getByTestId('cover-image')).toBeInTheDocument();
+  });
+
+  it('does not render a cover image when coverImage is omitted', () => {
+    render(<PostHeader {...baseProps} />);
+    expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
+  });
+
+  it('renders a caption overlay when a caption string is provided alongside an image', () => {
+    const coverImage = {
+      node: {
+        sourceUrl: 'https://example.com/image.jpg',
+        mediaDetails: { width: 800, height: 600, sizes: '', srcset: '' },
+        caption: '',
+      },
+    };
+    render(<PostHeader {...baseProps} coverImage={coverImage} caption="Photo by James" />);
+    expect(screen.getByText('Photo by James')).toBeInTheDocument();
+  });
+});

--- a/components/related-posts.test.tsx
+++ b/components/related-posts.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RelatedPosts from './related-posts';
+import { RelatedPost } from '../lib/types';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+jest.mock('./date', () => ({
+  __esModule: true,
+  default: ({ dateString }: { dateString: string }) => <time>{dateString}</time>,
+}));
+
+const mockPosts: RelatedPost[] = [
+  {
+    title: 'Related Post One',
+    slug: 'related-post-one',
+    date: '2023-01-15',
+    excerpt: '<p>Excerpt one</p>',
+    featuredImage: {
+      node: {
+        sourceUrl: 'https://example.com/image1.jpg',
+        mediaDetails: { height: 250, width: 400 },
+        srcSet: 'https://example.com/image1.jpg 400w',
+      },
+    },
+  },
+  {
+    title: 'Related Post Two',
+    slug: 'related-post-two',
+    date: '2023-06-20',
+    excerpt: '<p>Excerpt two</p>',
+    featuredImage: null,
+  },
+];
+
+describe('RelatedPosts', () => {
+  it('renders nothing when posts is empty', () => {
+    const { container } = render(<RelatedPosts posts={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the "You might also like" heading', () => {
+    render(<RelatedPosts posts={mockPosts} />);
+    expect(screen.getByRole('heading', { name: 'You might also like' })).toBeInTheDocument();
+  });
+
+  it('renders links to each post using its slug', () => {
+    render(<RelatedPosts posts={mockPosts} />);
+    // Each post with an image has two links (image + title), both pointing to the same slug
+    const linksToFirst = screen.getAllByRole('link', { name: 'Related Post One' });
+    expect(linksToFirst.length).toBeGreaterThan(0);
+    linksToFirst.forEach((link) => expect(link).toHaveAttribute('href', '/related-post-one'));
+
+    // Second post has no image so only the title link
+    expect(screen.getByRole('link', { name: 'Related Post Two' })).toHaveAttribute(
+      'href',
+      '/related-post-two'
+    );
+  });
+
+  it('renders each post title', () => {
+    render(<RelatedPosts posts={mockPosts} />);
+    expect(screen.getByText('Related Post One')).toBeInTheDocument();
+    expect(screen.getByText('Related Post Two')).toBeInTheDocument();
+  });
+
+  it('renders dates for each post', () => {
+    render(<RelatedPosts posts={mockPosts} />);
+    expect(screen.getByText('2023-01-15')).toBeInTheDocument();
+    expect(screen.getByText('2023-06-20')).toBeInTheDocument();
+  });
+
+  it('renders an image for posts that have a featured image', () => {
+    render(<RelatedPosts posts={mockPosts} />);
+    expect(screen.getByAltText('Related Post One')).toBeInTheDocument();
+  });
+
+  it('does not crash when a post has no featured image', () => {
+    render(<RelatedPosts posts={[mockPosts[1]]} />);
+    expect(screen.getByText('Related Post Two')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Today is Tuesday, so the focus is **Tests** — identifying untested components and adding meaningful coverage.

Before this PR, 15 of 26 components had no tests at all. This PR adds test files for 10 of those components, bringing the suite from 12 test files / ~125 tests to **22 test files / 158 tests**, all passing.

### New test files

| File | What's tested |
|---|---|
| `GenreDropdown.test.tsx` | Label, default "All Genres" option, all genre options rendered, selected value reflected, `onChange` called with correct value |
| `SortDropdown.test.tsx` | Label, default "Default" option, all sort options rendered, selected value reflected, `onChange` called with correct value |
| `cover-image.test.tsx` | No image rendered when `coverImage` is absent, image rendered when present, correct `alt` text, slug produces a link with the right `href`, `heroPost` prop switches to eager loading |
| `container.test.tsx` | Children rendered |
| `more-stories.test.tsx` | Correct number of `PostPreview` components rendered, titles passed through, empty array renders nothing |
| `related-posts.test.tsx` | Returns `null` for empty posts, "You might also like" heading, links with correct slugs, titles, dates, image rendered when present, no crash when `featuredImage` is null |
| `post-body.test.tsx` | HTML content rendered, multiple elements rendered, empty content handled, `DOMPurify.sanitize` called with `ADD_ATTR` options |
| `post-header.test.tsx` | Title rendered as a link to the slug, date section shown/hidden conditionally, cover image shown/hidden conditionally, caption overlay rendered when provided |
| `hero-post.test.tsx` | PostHeader rendered, Read More link present and pointing to slug, excerpt rendered, external anchor links stripped from excerpt |
| `layout.test.tsx` | Children rendered inside `<main>`, skip-to-main-content link present with correct `href`, `main` has `id="main-content"`, footer rendered, preview alert shown only in preview mode |

## Test plan

- [x] All 158 tests pass (`yarn test --no-coverage`)
- [x] No existing tests were modified
- [x] Each new test targets observable behaviour, not implementation details

https://claude.ai/code/session_01Xr8PJ4vMG9G9C4pZmEYocQ