### PR TITLE
test: add tests for calculateReadingTime and PrePost component

### DIFF
--- a/components/pre-post.test.tsx
+++ b/components/pre-post.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PrePost from './pre-post';
+
+const noTags = { edges: [] };
+const exiledTag = { edges: [{ node: { name: 'ExiledToryRemainerScum' } }] };
+const politicsTag = { edges: [{ node: { name: 'Politics' } }] };
+
+describe('PrePost', () => {
+  it('displays reading time when content is provided', () => {
+    render(<PrePost tags={noTags} date="2024-01-01" content="<p>Hello world</p>" />);
+    expect(screen.getByText(/min read/)).toBeInTheDocument();
+  });
+
+  it('does not display reading time when content is not provided', () => {
+    render(<PrePost tags={noTags} date="2024-01-01" />);
+    expect(screen.queryByText(/min read/)).not.toBeInTheDocument();
+  });
+
+  it('shows a note for posts tagged ExiledToryRemainerScum', () => {
+    render(<PrePost tags={exiledTag} date="2024-01-01" />);
+    expect(screen.getByText(/Originally posted on the now-defunct/)).toBeInTheDocument();
+  });
+
+  describe('Politics staleness note', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-01'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('shows staleness note for a Politics post more than 2 years old', () => {
+      render(<PrePost tags={politicsTag} date="2020-01-01" />);
+      expect(screen.getByText(/politics have changed over time/)).toBeInTheDocument();
+    });
+
+    it('does not show staleness note for a recent Politics post', () => {
+      render(<PrePost tags={politicsTag} date="2025-06-01" />);
+      expect(screen.queryByText(/politics have changed over time/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/components/utils.test.ts
+++ b/components/utils.test.ts
@@ -1,4 +1,4 @@
-import { getMonthNumber, getMonthName } from './utils';
+import { getMonthNumber, getMonthName, calculateReadingTime } from './utils';
 
 describe('getMonthNumber', () => {
   it.each([
@@ -54,5 +54,25 @@ describe('getMonthName', () => {
     for (let i = 1; i <= 12; i++) {
       expect(getMonthNumber(getMonthName(i))).toBe(i);
     }
+  });
+});
+
+describe('calculateReadingTime', () => {
+  it('returns 1 for an empty string', () => {
+    expect(calculateReadingTime('')).toBe(1);
+  });
+
+  it('returns 1 for content with fewer than 200 words', () => {
+    const content = '<p>' + 'word '.repeat(100).trim() + '</p>';
+    expect(calculateReadingTime(content)).toBe(1);
+  });
+
+  it('returns 2 for content with 201 words', () => {
+    const content = '<p>' + Array(201).fill('word').join(' ') + '</p>';
+    expect(calculateReadingTime(content)).toBe(2);
+  });
+
+  it('strips HTML tags before counting words', () => {
+    expect(calculateReadingTime('<h1>Title</h1><p>Hello world</p>')).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- **`calculateReadingTime` (utils.test.ts):** This pure function in `components/utils.tsx` had zero test coverage despite being called in production. Added 4 tests covering: the minimum return value of 1 for empty input, the 1-minute threshold for under-200-word content, the 2-minute result for 201-word content, and correct HTML-tag stripping before the word count.

- **`PrePost` component (pre-post.test.tsx):** This component had no test file at all. Added 5 tests covering:
  - Reading time is shown when `content` is provided, hidden when it is absent
  - The "Originally posted on the now-defunct Exiled Tory Remoaner Scum website" note appears for posts tagged `ExiledToryRemainerScum`
  - The politics-staleness note appears for a `Politics`-tagged post older than 2 years (using `jest.useFakeTimers` for determinism)
  - The politics-staleness note is correctly suppressed for a recent `Politics` post

## Test plan

- [x] `yarn test --testPathPatterns="utils\.test|pre-post\.test"` — all 37 tests pass (29 pre-existing + 8 new)
- [ ] Full test suite passes in CI

https://claude.ai/code/session_01HLbeztP1H4fKa7kAyXEGSm

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLbeztP1H4fKa7kAyXEGSm)_