### PR TITLE
test: add tests for sanitize utility and PrePost component

### DIFF
--- a/components/pre-post.test.tsx
+++ b/components/pre-post.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PrePost from './pre-post';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+const noTags = { edges: [] };
+
+describe('PrePost', () => {
+  it('shows reading time when content is provided', () => {
+    // 201 words → Math.ceil(201/200) = 2 min read
+    const content = Array(201).fill('word').join(' ');
+    render(<PrePost tags={noTags} date="2023-01-01" content={content} />);
+    expect(screen.getByText('2 min read')).toBeInTheDocument();
+  });
+
+  it('does not show reading time when content is absent', () => {
+    render(<PrePost tags={noTags} date="2023-01-01" />);
+    expect(screen.queryByText(/min read/)).not.toBeInTheDocument();
+  });
+
+  it('shows the ExiledToryRemainerScum note when the tag is present', () => {
+    const tags = { edges: [{ node: { name: 'ExiledToryRemainerScum' } }] };
+    render(<PrePost tags={tags} date="2023-01-01" />);
+    expect(screen.getByText(/Originally posted on the now-defunct/)).toBeInTheDocument();
+  });
+
+  it('shows an age notice for a Politics post more than 2 years old', () => {
+    const tags = { edges: [{ node: { name: 'Politics' } }] };
+    render(<PrePost tags={tags} date="2020-01-01" />);
+    expect(screen.getByText(/This post is \d+ years old/)).toBeInTheDocument();
+  });
+
+  it('does not show an age notice for a recent Politics post', () => {
+    const recentYear = new Date().getFullYear();
+    const tags = { edges: [{ node: { name: 'Politics' } }] };
+    render(<PrePost tags={tags} date={`${recentYear}-01-01`} />);
+    expect(screen.queryByText(/This post is \d+ years old/)).not.toBeInTheDocument();
+  });
+});

--- a/lib/sanitize.test.ts
+++ b/lib/sanitize.test.ts
@@ -1,0 +1,28 @@
+import { sanitize } from './sanitize';
+import DOMPurify from 'dompurify';
+
+jest.mock('dompurify', () => ({
+  __esModule: true,
+  default: {
+    sanitize: jest.fn((html: string) => html),
+  },
+}));
+
+describe('sanitize', () => {
+  beforeEach(() => {
+    (DOMPurify.sanitize as jest.Mock).mockClear();
+  });
+
+  it('delegates to DOMPurify.sanitize and returns its output', () => {
+    (DOMPurify.sanitize as jest.Mock).mockReturnValueOnce('clean html');
+    const result = sanitize('<b>input</b>');
+    expect(DOMPurify.sanitize).toHaveBeenCalledWith('<b>input</b>', undefined);
+    expect(result).toBe('clean html');
+  });
+
+  it('forwards an optional config object to DOMPurify.sanitize', () => {
+    const config = { ALLOWED_TAGS: ['b'] };
+    sanitize('<b>bold</b>', config);
+    expect(DOMPurify.sanitize).toHaveBeenCalledWith('<b>bold</b>', config);
+  });
+});


### PR DESCRIPTION
## Summary

- **`lib/sanitize.test.ts`** (2 tests): verifies that `DOMPurify.sanitize` is called with the correct HTML string and that an optional config object is forwarded — the two meaningful code paths in this security-relevant utility.
- **`components/pre-post.test.tsx`** (5 tests): covers all conditional rendering branches in the `PrePost` component:
  - Reading time shown when `content` is provided, hidden when absent
  - `ExiledToryRemainerScum` note rendered when the matching tag is present
  - Politics age notice shown only for posts older than two years, suppressed for recent posts

## Why these two files

Both were completely untested. `sanitize.ts` wraps DOMPurify for XSS protection — worth verifying the delegation works correctly. `PrePost` has clear branching logic tied to tag names and post age that could silently regress.

## Test results

All 7 new tests pass alongside the existing suite.

## Category

Sunday → randomly selected **Tests** (26 mod 5 = 1)

https://claude.ai/code/session_01Aj7F93USbcFr3toffcX9uJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aj7F93USbcFr3toffcX9uJ)_