### PR TITLE
Add RSS feed and subscribe link in footer

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -11,6 +11,7 @@ export default function Footer() {
           <FlexRow>
             <ArchiveDropdown />
             <p>World Of Winfield</p>
+            <RssLink href="/api/feed">Subscribe via RSS</RssLink>
           </FlexRow>
           <IconAttribution>
             Icons made by{' '}
@@ -63,6 +64,18 @@ const FlexRow = styled.div`
 
   @media screen and (max-width: 768px) {
     flex-direction: column;
+  }
+`;
+
+const RssLink = styled.a`
+  color: ${colours.white};
+  text-decoration: none;
+  font-size: 1rem;
+  letter-spacing: 1px;
+  align-self: center;
+
+  &:hover {
+    text-decoration: underline;
   }
 `;
 

--- a/pages/api/feed.ts
+++ b/pages/api/feed.ts
@@ -1,0 +1,40 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getAllPostsForHome } from '../../lib/api';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const data = await getAllPostsForHome(false);
+  const posts = data.posts.edges.map(({ node }: { node: Record<string, unknown> }) => node);
+
+  const siteUrl = 'https://www.worldofwinfield.com';
+
+  const items = posts
+    .map((post: { title: string; slug: string; date: string; excerpt: string }) => {
+      const excerpt = post.excerpt
+        ? post.excerpt.replace(/<[^>]*>/g, '').trim()
+        : '';
+      return `
+    <item>
+      <title><![CDATA[${post.title}]]></title>
+      <link>${siteUrl}/posts/${post.slug}</link>
+      <guid isPermaLink="true">${siteUrl}/posts/${post.slug}</guid>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <description><![CDATA[${excerpt}]]></description>
+    </item>`;
+    })
+    .join('');
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>World Of Winfield</title>
+    <link>${siteUrl}</link>
+    <description>The latest posts from World Of Winfield</description>
+    <language>en-gb</language>
+    <atom:link href="${siteUrl}/api/feed" rel="self" type="application/rss+xml"/>
+    ${items}
+  </channel>
+</rss>`;
+
+  res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8');
+  res.status(200).send(feed);
+}

--- a/pages/api/feed.ts
+++ b/pages/api/feed.ts
@@ -3,7 +3,7 @@ import { getAllPostsForHome } from '../../lib/api';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const data = await getAllPostsForHome(false);
-  const posts = data.posts.edges.map(({ node }: { node: Record<string, unknown> }) => node);
+  const posts = data.edges.map(({ node }: { node: Record<string, unknown> }) => node);
 
   const siteUrl = 'https://www.worldofwinfield.com';
 


### PR DESCRIPTION
## Summary
- Adds a valid RSS 2.0 feed at `/api/feed` using the existing `getAllPostsForHome` GraphQL query
- Includes title, link, pubDate, and description (excerpt) for each post
- Adds a "Subscribe via RSS" link to the footer, styled to match the existing footer palette

Closes #359

## Test plan
- [ ] Visit `/api/feed` and verify a valid RSS 2.0 XML response is returned
- [ ] Open the feed URL in an RSS reader (e.g. Feedly, NetNewsWire) and confirm posts load correctly
- [ ] Verify "Subscribe via RSS" link appears in the footer and links to `/api/feed`
- [ ] Check footer layout looks correct on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)