### PR TITLE
chore(typescript): remove explicit `any` usages and add return types

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,3 +1,5 @@
+import type { AdjacentPost, RelatedPost } from './types';
+
 const API_URL = process.env.NEXT_PUBLIC_WORDPRESS_API_URL;
 
 async function fetchAPI(query = '', { variables }: Record<string, unknown> = {}) {
@@ -480,7 +482,7 @@ export async function getPostsByTag(tag: string) {
   return data.posts.nodes;
 }
 
-export async function getRelatedPosts(tag: string, excludeSlug: string) {
+export async function getRelatedPosts(tag: string, excludeSlug: string): Promise<RelatedPost[]> {
   const data = await fetchAPI(
     `
     query GetRelatedPosts($tag: String!) {
@@ -507,12 +509,15 @@ export async function getRelatedPosts(tag: string, excludeSlug: string) {
       variables: { tag },
     },
   );
-  return (data.posts.nodes as { slug: string }[])
+  return (data.posts.nodes as RelatedPost[])
     .filter((post) => post.slug !== excludeSlug)
     .slice(0, 3);
 }
 
-export async function getAdjacentPosts(date: string) {
+export async function getAdjacentPosts(date: string): Promise<{
+  previousPost: AdjacentPost | null;
+  nextPost: AdjacentPost | null;
+}> {
   const parsedDate = new Date(date);
   const year = parsedDate.getFullYear();
   const month = parsedDate.getMonth() + 1;

--- a/pages/_app.test.tsx
+++ b/pages/_app.test.tsx
@@ -1,13 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
+import type { AppProps } from 'next/app';
 import MyApp from './_app';
-
-type AppProps = {
-  Component: React.ComponentType;
-  pageProps: Record<string, any>;
-  router: any;
-};
 
 const pageContent = 'test content';
 
@@ -17,11 +12,12 @@ jest.mock('@next/third-parties/google', () => ({
 
 describe('App tests', () => {
   it('should load the app page and  display content', () => {
-    const props: AppProps = {
+    // Cast minimal mock object to AppProps — router is not used by MyApp
+    const props = {
       Component: () => <div>{pageContent}</div>,
       pageProps: {},
       router: {},
-    };
+    } as unknown as AppProps;
 
     render(<MyApp {...props} />);
     expect(screen.queryByText('test content')).toBeInTheDocument();

--- a/pages/_app.test.tsx
+++ b/pages/_app.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import React from 'react';
 import type { AppProps } from 'next/app';
+import React from 'react';
 import MyApp from './_app';
 
 const pageContent = 'test content';

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,8 +1,8 @@
 import createCache, { EmotionCache } from '@emotion/cache';
 import createEmotionServer from '@emotion/server/create-instance';
 import type { AppProps } from 'next/app';
-import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
 import type { AppType } from 'next/dist/shared/lib/utils';
+import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
 import type { ComponentType } from 'react';
 
 const EMOTION_KEY = 'css';
@@ -51,10 +51,10 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
       // Cast required: Next.js Enhancer<AppType> expects (AppType) => AppType, but we return
       // a wrapper that passes an extra emotionCache prop — no way to express this without assertion.
       enhanceApp: (App: AppType) =>
-        (function EnhancedApp(props: AppProps) {
+        function EnhancedApp(props: AppProps) {
           const TypedApp = App as ComponentType<AppProps & { emotionCache: EmotionCache }>;
           return <TypedApp emotionCache={cache} {...props} />;
-        }) as unknown as AppType,
+        } as unknown as AppType,
     });
 
   const initialProps = await Document.getInitialProps(ctx);

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,9 @@
-import createCache from '@emotion/cache';
+import createCache, { EmotionCache } from '@emotion/cache';
 import createEmotionServer from '@emotion/server/create-instance';
+import type { AppProps } from 'next/app';
 import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
+import type { AppType } from 'next/dist/shared/lib/utils';
+import type { ComponentType } from 'react';
 
 const EMOTION_KEY = 'css';
 
@@ -45,10 +48,13 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
   const originalRenderPage = ctx.renderPage;
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App: any) =>
-        function EnhancedApp(props: any) {
-          return <App emotionCache={cache} {...props} />;
-        },
+      // Cast required: Next.js Enhancer<AppType> expects (AppType) => AppType, but we return
+      // a wrapper that passes an extra emotionCache prop — no way to express this without assertion.
+      enhanceApp: (App: AppType) =>
+        (function EnhancedApp(props: AppProps) {
+          const TypedApp = App as ComponentType<AppProps & { emotionCache: EmotionCache }>;
+          return <TypedApp emotionCache={cache} {...props} />;
+        }) as unknown as AppType,
     });
 
   const initialProps = await Document.getInitialProps(ctx);


### PR DESCRIPTION
## Summary

- **`pages/_document.tsx`**: Replace `any` on `enhanceApp`/`EnhancedApp` params with proper `AppType`/`AppProps` types. A focused `as unknown as AppType` cast is kept with an explanatory comment — Next.js's `Enhancer<AppType>` constraint (which requires the function to return the exact same `AppType` it receives) makes it impossible to express the emotionCache wrapper without an assertion.
- **`pages/_app.test.tsx`**: Remove local `AppProps` shadow type that contained `Record<string, any>` and an `any` router field. Now imports `AppProps` from `next/app` and uses `as unknown as AppProps` for the minimal test mock (the router field is not used by `MyApp`).
- **`lib/api.ts`**: Import `AdjacentPost`/`RelatedPost` from `./types`; add explicit `Promise<…>` return types to `getAdjacentPosts` and `getRelatedPosts`; fix an over-narrowed cast `as { slug: string }[]` → `as RelatedPost[]` so the full shape returned by the GraphQL query is preserved.

## Test plan

- [x] `tsc --noEmit` passes with zero errors after changes
- [x] All 184 existing tests pass (`yarn test`)
- [x] No new `any` types introduced

https://claude.ai/code/session_01MX3JEgxwaBHEXF8DjnGuJx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MX3JEgxwaBHEXF8DjnGuJx)_