### PR TITLE
chore(typescript): convert 404.jsx to TSX and fix null safety in countries-visited

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,6 +4,10 @@ import Container from '../components/container';
 import Layout from '../components/layout';
 import { colours } from '../pages/_app';
 
+interface BlockProps {
+  backgroundColour: string;
+}
+
 export default function Custom404() {
   const words = ['Why', 'are', 'you', 'here?'];
   const blockColours = [
@@ -16,7 +20,7 @@ export default function Custom404() {
     colours.blueish,
   ];
 
-  const shuffleArray = (array) => {
+  const shuffleArray = (array: string[]): string[] => {
     for (let i = array.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [array[i], array[j]] = [array[j], array[i]];
@@ -63,7 +67,7 @@ const Grid = styled.div`
   }
 `;
 
-const Block = styled.div`
+const Block = styled.div<BlockProps>`
   background-color: ${(props) => props.backgroundColour};
   color: white;
   padding: 0;

--- a/pages/countries-visited.tsx
+++ b/pages/countries-visited.tsx
@@ -5,7 +5,9 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 
-const processData = (rawData: string[][]): Record<string, { country: string; visited: string }[]> => {
+const processData = (
+  rawData: string[][],
+): Record<string, { country: string; visited: string }[]> => {
   const continents = [
     'Europe',
     'North America',

--- a/pages/countries-visited.tsx
+++ b/pages/countries-visited.tsx
@@ -5,7 +5,7 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 
-const processData = (rawData: string[][]) => {
+const processData = (rawData: string[][]): Record<string, { country: string; visited: string }[]> => {
   const continents = [
     'Europe',
     'North America',
@@ -42,7 +42,7 @@ const processData = (rawData: string[][]) => {
   return result;
 };
 
-const fetchDataFromGoogleSheets = async () => {
+const fetchDataFromGoogleSheets = async (): Promise<string[][] | null> => {
   try {
     const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY;
     const sheetID = '1OBRmcLtmwbb8AjoUj8F9wUe5j7AERFlI-iG2iYkA3Jg';
@@ -207,7 +207,7 @@ const ContentContainer = styled.section`
 
 export async function getServerSideProps() {
   const rawData = await fetchDataFromGoogleSheets();
-  const transformedData = processData(rawData);
+  const transformedData = rawData ? processData(rawData) : {};
 
   return {
     props: {


### PR DESCRIPTION
## Summary

- **Convert `pages/404.jsx` → `pages/404.tsx`**: adds a `BlockProps` interface for the emotion `styled.div` component (so the `backgroundColour` prop is typed), types the `shuffleArray` parameter as `string[]`, and brings the page under strict TypeScript checking
- **Explicit return types in `countries-visited.tsx`**: `processData` now declares `Record<string, { country: string; visited: string }[]>` and `fetchDataFromGoogleSheets` declares `Promise<string[][] | null>`
- **Null safety fix in `getServerSideProps`**: `fetchDataFromGoogleSheets` can return `null` on network/API failure, but `processData` only accepts `string[][]` — passing `null` would have caused a runtime crash; guarded with `rawData ? processData(rawData) : {}`

All changes pass `tsc --noEmit` with zero errors on `strict: true`.

## Test plan

- [ ] Visit `/404` — page should render with the coloured word blocks as before
- [ ] Visit `/countries-visited` — page should load normally when the Google Sheets API succeeds
- [ ] Simulate a Google Sheets API failure (e.g. bad key in env) — page should now render with empty data rather than crashing

https://claude.ai/code/session_016YzTCFRNocrme9Rk8f5nLH

---
_Generated by [Claude Code](https://claude.ai/code/session_016YzTCFRNocrme9Rk8f5nLH)_