### PR TITLE
test: add tests for imageLoader, PostNavigation, and FavouritesHubLink

### DIFF
--- a/components/favourites-hub-link.test.tsx
+++ b/components/favourites-hub-link.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import FavouritesHubLink from './favourites-hub-link';
+
+describe('FavouritesHubLink', () => {
+  it('renders a link back to the favourites hub', () => {
+    render(<FavouritesHubLink />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/favourites');
+  });
+
+  it('displays the correct link text', () => {
+    render(<FavouritesHubLink />);
+    expect(screen.getByText('← Back to all favourites')).toBeInTheDocument();
+  });
+});

--- a/components/post-navigation.test.tsx
+++ b/components/post-navigation.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import PostNavigation from './post-navigation';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+describe('PostNavigation', () => {
+  it('renders nothing when both previousPost and nextPost are null', () => {
+    const { container } = render(<PostNavigation previousPost={null} nextPost={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the previous post link with direction label and title', () => {
+    const previousPost = { title: 'Older Post Title', slug: 'older-post' };
+    render(<PostNavigation previousPost={previousPost} nextPost={null} />);
+
+    expect(screen.getByText('← Older')).toBeInTheDocument();
+    expect(screen.getByText('Older Post Title')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/older-post');
+  });
+
+  it('renders the next post link with direction label and title', () => {
+    const nextPost = { title: 'Newer Post Title', slug: 'newer-post' };
+    render(<PostNavigation previousPost={null} nextPost={nextPost} />);
+
+    expect(screen.getByText('Newer →')).toBeInTheDocument();
+    expect(screen.getByText('Newer Post Title')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/newer-post');
+  });
+});

--- a/lib/imageLoader.test.ts
+++ b/lib/imageLoader.test.ts
@@ -1,0 +1,18 @@
+import imageLoader from './imageLoader';
+
+describe('imageLoader', () => {
+  it('returns local paths unchanged', () => {
+    const result = imageLoader({ src: '/images/photo.jpg', width: 800, quality: 75 });
+    expect(result).toBe('/images/photo.jpg');
+  });
+
+  it('transforms external URLs to the Jetpack CDN format', () => {
+    const result = imageLoader({ src: 'https://example.com/uploads/photo.jpg', width: 600, quality: 80 });
+    expect(result).toBe('https://i0.wp.com/example.com/uploads/photo.jpg?w=600&q=80&strip=all');
+  });
+
+  it('defaults quality to 75 when not provided', () => {
+    const result = imageLoader({ src: 'https://example.com/uploads/photo.jpg', width: 400 });
+    expect(result).toBe('https://i0.wp.com/example.com/uploads/photo.jpg?w=400&q=75&strip=all');
+  });
+});

--- a/lib/imageLoader.test.ts
+++ b/lib/imageLoader.test.ts
@@ -7,7 +7,11 @@ describe('imageLoader', () => {
   });
 
   it('transforms external URLs to the Jetpack CDN format', () => {
-    const result = imageLoader({ src: 'https://example.com/uploads/photo.jpg', width: 600, quality: 80 });
+    const result = imageLoader({
+      src: 'https://example.com/uploads/photo.jpg',
+      width: 600,
+      quality: 80,
+    });
     expect(result).toBe('https://i0.wp.com/example.com/uploads/photo.jpg?w=600&q=80&strip=all');
   });
 


### PR DESCRIPTION
## Summary

Today's focus (Tuesday = Tests): added 8 new tests across 3 previously-untested areas.

- **`lib/imageLoader.test.ts`** (3 tests): verifies that local paths (`/...`) pass through unchanged, external URLs are correctly proxied via the Jetpack CDN (`https://i0.wp.com/...`), and the quality parameter defaults to 75 when omitted
- **`components/post-navigation.test.tsx`** (3 tests): verifies the component renders nothing when both adjacent posts are null, and renders the correct direction label, title text, and `href` for both previous and next post links
- **`components/favourites-hub-link.test.tsx`** (2 tests): verifies the back-link renders with `href="/favourites"` and the expected label text

All 8 tests pass. No production code was changed.

## Test plan

- [x] `yarn test --testPathPatterns="imageLoader|post-navigation|favourites-hub-link"` — all 8 tests green
- [x] No changes to production source files

https://claude.ai/code/session_01LM8EYkALof3nohGE1HGDYA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LM8EYkALof3nohGE1HGDYA)_