### PR TITLE
perf: image sizing hints, quality consistency, and font/CDN preloading

### DIFF
--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -124,7 +124,7 @@ export default function HomepageBlock({
                 ? '(max-width: 768px) 50vw, (max-width: 1200px) 15vw, 270px'
                 : '(max-width: 768px) 100vw, (max-width: 1200px) 30vw, 550px'
             }
-            quality={80}
+            quality={75}
             loading={eagerOrLazy}
           />
         )

--- a/components/related-posts.tsx
+++ b/components/related-posts.tsx
@@ -22,6 +22,7 @@ export default function RelatedPosts({ posts }: RelatedPostsProps) {
                     alt={post.title}
                     width={400}
                     height={250}
+                    sizes="(max-width: 768px) 100vw, (max-width: 960px) 33vw, 320px"
                     style={{ objectFit: 'cover', width: '100%', height: '180px' }}
                   />
                 </Link>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -62,6 +62,14 @@ function MyApp({
     <CacheProvider value={emotionCache}>
       <Head>
         <title>World Of Winfield</title>
+        <link
+          rel="preload"
+          href="/fonts/Oswald-VariableFont_rght.ttf"
+          as="font"
+          type="font/truetype"
+          crossOrigin="anonymous"
+        />
+        <link rel="preconnect" href="https://i0.wp.com" crossOrigin="anonymous" />
         <link rel="preconnect" href="https://www.googletagmanager.com" />
         <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
       </Head>


### PR DESCRIPTION
## Summary

Three targeted performance improvements for Wednesday's optimisation pass:

### 1. `related-posts.tsx` — add `sizes` to Image
The related-posts grid renders images at ~1/3 viewport width on desktop (3-column grid, max-width 60rem section), but the Image had no `sizes` attribute. Without `sizes`, browsers default to treating the image as `100vw` and the Jetpack CDN (`i0.wp.com`) is asked for a full-viewport-width image. Adding `sizes="(max-width: 768px) 100vw, (max-width: 960px) 33vw, 320px"` means the browser requests a correctly-sized image (~320px on desktop vs potentially 1200px+ before).

### 2. `homepage-block.tsx` — normalise `quality` to 75
One Image branch used `quality={80}` while all other Image usages in this file (and across the codebase) use `quality={75}`. Normalised for consistency so all Jetpack CDN requests use the same `?q=75` parameter.

### 3. `pages/_app.tsx` — font preload + CDN preconnect
- Added `<link rel="preload">` for `Oswald-VariableFont_rght.ttf` so the browser discovers and fetches the font earlier in the page lifecycle, reducing the flash of unstyled text and improving FCP.
- Added `<link rel="preconnect">` for `https://i0.wp.com` (the Jetpack CDN serving all WordPress images) so the TCP/TLS handshake is warmed up before the first image request fires.

## Test plan
- [ ] Homepage loads with no layout shift on the block grid
- [ ] Related posts section shows correctly-sized images on a post page
- [ ] Network tab shows `i0.wp.com` preconnect in the waterfall (connection established early)
- [ ] Font loads without FOUT on first paint
- [ ] No visual regressions on related posts, homepage blocks, or any page using the Oswald font

https://claude.ai/code/session_01RgYAoDTsD7QNrXGAva92tz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgYAoDTsD7QNrXGAva92tz)_