### PR TITLE
Replace inline style props with Emotion styled components in dropdown components

### DIFF
--- a/components/GenreDropdown.tsx
+++ b/components/GenreDropdown.tsx
@@ -19,10 +19,8 @@ const GenreDropdown: React.FC<GenreDropdownProps> = ({
   selectId = 'genre-select',
 }) => {
   return (
-    <div style={{ marginBottom: '1rem' }}>
-      <label htmlFor={selectId} style={{ marginRight: '0.5rem' }}>
-        {filterLabel}
-      </label>
+    <Wrapper>
+      <Label htmlFor={selectId}>{filterLabel}</Label>
       <StyledSelect id={selectId} value={selectedGenre} onChange={(e) => onChange(e.target.value)}>
         {allOptionText && <option value="">{allOptionText}</option>}
         {genres.map((genre) => (
@@ -31,9 +29,17 @@ const GenreDropdown: React.FC<GenreDropdownProps> = ({
           </option>
         ))}
       </StyledSelect>
-    </div>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  margin-bottom: 1rem;
+`;
+
+const Label = styled.label`
+  margin-right: 0.5rem;
+`;
 
 const StyledSelect = styled.select`
   padding: 0.5rem;

--- a/components/SortDropdown.tsx
+++ b/components/SortDropdown.tsx
@@ -9,10 +9,8 @@ type SortDropdownProps = {
 
 const SortDropdown: React.FC<SortDropdownProps> = ({ options, selected, onChange }) => {
   return (
-    <div style={{ margin: '1rem 0', textAlign: 'center' }}>
-      <label htmlFor="sort-select" style={{ marginRight: '0.5rem' }}>
-        Sort by:
-      </label>
+    <Wrapper>
+      <Label htmlFor="sort-select">Sort by:</Label>
       <Select id="sort-select" value={selected} onChange={(e) => onChange(e.target.value)}>
         <option value="">Default</option>
         {options.map((opt) => (
@@ -21,9 +19,18 @@ const SortDropdown: React.FC<SortDropdownProps> = ({ options, selected, onChange
           </option>
         ))}
       </Select>
-    </div>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  margin: 1rem 0;
+  text-align: center;
+`;
+
+const Label = styled.label`
+  margin-right: 0.5rem;
+`;
 
 const Select = styled.select`
   padding: 0.5rem;

--- a/components/post-title.tsx
+++ b/components/post-title.tsx
@@ -6,10 +6,7 @@ import { colours } from '../pages/_app';
 export default function PostTitle({ backgroundColour, children }: PostTitleProps) {
   return (
     <StyledTitleContainer backgroundColour={backgroundColour ?? ''}>
-      <Title
-        colour={colours.white}
-        dangerouslySetInnerHTML={{ __html: sanitize(children) }}
-      />
+      <Title colour={colours.white} dangerouslySetInnerHTML={{ __html: sanitize(children) }} />
     </StyledTitleContainer>
   );
 }

--- a/components/post-title.tsx
+++ b/components/post-title.tsx
@@ -8,7 +8,7 @@ export default function PostTitle({ backgroundColour, children }: PostTitleProps
     <StyledTitleContainer backgroundColour={backgroundColour ?? ''}>
       <Title
         colour={colours.white}
-        dangerouslySetInnerHTML={{ __html: sanitize(children as string) }}
+        dangerouslySetInnerHTML={{ __html: sanitize(children) }}
       />
     </StyledTitleContainer>
   );


### PR DESCRIPTION
## Summary

- `SortDropdown.tsx` and `GenreDropdown.tsx` both used raw `style=` attributes on `div` and `label` elements
- Extracted these into named Emotion styled components (`Wrapper`, `Label`) to match the pattern used throughout the rest of the codebase
- No behaviour changes — purely a consistency/style fix

## Test plan

- [ ] Verify sort dropdown still renders and functions on pages that use `SortDropdown`
- [ ] Verify genre dropdown still renders and functions on pages that use `GenreDropdown`
- [ ] Visual check that spacing is unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_0191wHuvc4nMee8FDRSyHhAa)_