### PR TITLE
a11y: add aria-label to Read More links in post preview cards

### DIFF
--- a/components/post-preview.test.tsx
+++ b/components/post-preview.test.tsx
@@ -65,12 +65,17 @@ describe('PostPreview', () => {
 
   it('renders a "Read More" link', () => {
     render(<PostPreview {...baseProps} />);
-    expect(screen.getByRole('link', { name: 'Read more about Test Post Title' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Read more about Test Post Title' }),
+    ).toBeInTheDocument();
   });
 
   it('"Read More" link href matches the post slug', () => {
     render(<PostPreview {...baseProps} />);
-    expect(screen.getByRole('link', { name: 'Read more about Test Post Title' })).toHaveAttribute('href', '/test-post');
+    expect(screen.getByRole('link', { name: 'Read more about Test Post Title' })).toHaveAttribute(
+      'href',
+      '/test-post',
+    );
   });
 
   it('renders the excerpt text content', () => {

--- a/components/post-preview.test.tsx
+++ b/components/post-preview.test.tsx
@@ -65,12 +65,12 @@ describe('PostPreview', () => {
 
   it('renders a "Read More" link', () => {
     render(<PostPreview {...baseProps} />);
-    expect(screen.getByRole('link', { name: 'Read More' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Read more about Test Post Title' })).toBeInTheDocument();
   });
 
   it('"Read More" link href matches the post slug', () => {
     render(<PostPreview {...baseProps} />);
-    expect(screen.getByRole('link', { name: 'Read More' })).toHaveAttribute('href', '/test-post');
+    expect(screen.getByRole('link', { name: 'Read more about Test Post Title' })).toHaveAttribute('href', '/test-post');
   });
 
   it('renders the excerpt text content', () => {

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -63,7 +63,9 @@ export default function PostPreview({
           <DateComponent dateString={date} />
         </PostedDate>
         <CardExcerpt dangerouslySetInnerHTML={{ __html: sanitizedExcerpt }} />
-        <ReadMoreLink href={`/${slug}`} aria-label={`Read more about ${title}`}>Read More</ReadMoreLink>
+        <ReadMoreLink href={`/${slug}`} aria-label={`Read more about ${title}`}>
+          Read More
+        </ReadMoreLink>
       </ContentSide>
     </CardContainer>
   );

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -63,7 +63,7 @@ export default function PostPreview({
           <DateComponent dateString={date} />
         </PostedDate>
         <CardExcerpt dangerouslySetInnerHTML={{ __html: sanitizedExcerpt }} />
-        <ReadMoreLink href={`/${slug}`}>Read More</ReadMoreLink>
+        <ReadMoreLink href={`/${slug}`} aria-label={`Read more about ${title}`}>Read More</ReadMoreLink>
       </ContentSide>
     </CardContainer>
   );


### PR DESCRIPTION
## Accessibility improvement

**Category:** Semantic HTML / Link Purpose
**File:** components/post-preview.tsx:66
**WCAG criterion:** 2.4.9 Link Purpose – Link Only (Level AAA) / 2.4.6 Headings and Labels (Level AA)

### Problem

Each post preview card renders a "Read More" link (`<ReadMoreLink>`). When multiple post cards appear on the blog listing page, screen reader users navigating by links (a common pattern) hear a list of identical "Read More" links with no context about which post each one leads to. This makes it impossible to distinguish posts without reading the surrounding content.

### Fix

Added `aria-label={\`Read more about \${title}\`}` to the `ReadMoreLink` component. The visible text stays "Read More" for sighted users, while screen readers announce "Read more about [Post Title]", giving keyboard and assistive-technology users the same context sighted users get from the card layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)