### PR TITLE
fix(a11y/seo): remove aria-label anti-pattern on paragraph and add explicit SEO to tag pages

### DIFF
--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -132,7 +132,7 @@ export default function HomepageBlock({
 
       {url && date && (
         <StyledLink href={url}>
-          {title !== PLACEHOLDER && title !== RANDOM_PHOTO && <p aria-label={title}>{title}</p>}
+          {title !== PLACEHOLDER && title !== RANDOM_PHOTO && <p>{title}</p>}
           {date && title !== PLACEHOLDER && <p className="date">{formatDate(date)}</p>}
         </StyledLink>
       )}

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -11,6 +11,12 @@ import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
+const goalsSeo = {
+  opengraphTitle: 'Posts About Goals | World Of Winfield',
+  opengraphDescription: 'A collection of posts about goals from World Of Winfield.',
+  opengraphSiteName: 'World Of Winfield',
+};
+
 export default function Post({ posts }: PostsProps) {
   const router = useRouter();
 
@@ -19,7 +25,7 @@ export default function Post({ posts }: PostsProps) {
   }
 
   return (
-    <Layout preview={null} seo={posts[0]?.seo} title="Posts About Goals">
+    <Layout preview={null} seo={goalsSeo} title="Posts About Goals | World Of Winfield">
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -11,6 +11,12 @@ import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
+const musicSeo = {
+  opengraphTitle: 'Posts About Music | World Of Winfield',
+  opengraphDescription: 'A collection of posts about music from World Of Winfield.',
+  opengraphSiteName: 'World Of Winfield',
+};
+
 export default function Post({ posts }: PostsProps) {
   const router = useRouter();
 
@@ -19,7 +25,7 @@ export default function Post({ posts }: PostsProps) {
   }
 
   return (
-    <Layout preview={null} seo={posts[0]?.seo} title="Posts About Music">
+    <Layout preview={null} seo={musicSeo} title="Posts About Music | World Of Winfield">
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -11,6 +11,12 @@ import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
+const politicsSeo = {
+  opengraphTitle: 'Posts About Politics | World Of Winfield',
+  opengraphDescription: 'A collection of posts about politics from World Of Winfield.',
+  opengraphSiteName: 'World Of Winfield',
+};
+
 export default function Post({ posts }: PostsProps) {
   const router = useRouter();
 
@@ -19,7 +25,7 @@ export default function Post({ posts }: PostsProps) {
   }
 
   return (
-    <Layout preview={null} seo={posts[0]?.seo} title="Posts About Politics">
+    <Layout preview={null} seo={politicsSeo} title="Posts About Politics | World Of Winfield">
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -11,6 +11,12 @@ import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
+const travelSeo = {
+  opengraphTitle: 'Posts About Travel | World Of Winfield',
+  opengraphDescription: 'A collection of posts about travel from World Of Winfield.',
+  opengraphSiteName: 'World Of Winfield',
+};
+
 export default function Post({ posts }: PostsProps) {
   const router = useRouter();
 
@@ -19,7 +25,7 @@ export default function Post({ posts }: PostsProps) {
   }
 
   return (
-    <Layout preview={null} seo={posts[0]?.seo} title="Posts About Travel">
+    <Layout preview={null} seo={travelSeo} title="Posts About Travel | World Of Winfield">
       <Container>
         {router.isFallback ? (
           <PostTitle>Loading…</PostTitle>


### PR DESCRIPTION
## Summary

- **Accessibility**: Remove `aria-label` from a `<p>` element in `homepage-block.tsx`. Applying `aria-label` to a non-interactive element is an ARIA anti-pattern — it can confuse assistive technologies and is redundant when the element already contains visible text.
- **SEO**: Replace `seo={posts[0]?.seo}` with explicit, page-specific SEO objects on the Music, Politics, Travel, and Goals tag-filter pages. The previous approach was fragile: if no posts existed the `seo` prop would be `undefined`, causing those pages to fall back to generic defaults. It also surfaced a random post's metadata as the page-level Open Graph data, which is misleading to search engines and social-sharing previews.

## Changes

| File | Change |
|---|---|
| `components/homepage-block.tsx` | Remove `aria-label={title}` from `<p>` (line 135) |
| `pages/music.tsx` | Add hardcoded `musicSeo` object; update `title` prop |
| `pages/politics.tsx` | Add hardcoded `politicsSeo` object; update `title` prop |
| `pages/travel.tsx` | Add hardcoded `travelSeo` object; update `title` prop |
| `pages/goals.tsx` | Add hardcoded `goalsSeo` object; update `title` prop |

## Test plan

- [ ] Visit `/music`, `/politics`, `/travel`, `/goals` and confirm `<title>` and `og:title` in page source match the new values (e.g. "Posts About Music | World Of Winfield")
- [ ] Confirm `og:description` is present and correct on each of those pages
- [ ] Check homepage blocks in a screen reader / axe scan — the paragraph title should no longer emit a redundant `aria-label` announcement

https://claude.ai/code/session_01XFAVFFh5GE9maqY2FWAZhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFAVFFh5GE9maqY2FWAZhZ)_