### PR TITLE
test: add tests for Intro, Meta, and SectionSeparator components

### DIFF
--- a/components/intro.test.tsx
+++ b/components/intro.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import Intro from './intro';
 import { JamesImagesProps } from '../lib/types';
+import Intro from './intro';
 
 jest.mock('../pages/_app', () => ({
   colours: {

--- a/components/intro.test.tsx
+++ b/components/intro.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import Intro from './intro';
+import { JamesImagesProps } from '../lib/types';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+const mockJamesImages: JamesImagesProps = {
+  edges: Array.from({ length: 20 }, (_, i) => ({
+    node: {
+      title: `James Photo ${i + 1}`,
+      featuredImage: {
+        node: {
+          mediaDetails: { height: 300, width: 300, sizes: '' },
+          sourceUrl: `/images/photo-${i + 1}.jpg`,
+          srcset: '',
+        },
+      },
+    },
+  })),
+};
+
+describe('Intro', () => {
+  it('renders a section element', () => {
+    const { container } = render(<Intro jamesImages={mockJamesImages} />);
+    expect(container.querySelector('section')).toBeInTheDocument();
+  });
+
+  it('renders a visually hidden heading with the site name', () => {
+    render(<Intro jamesImages={mockJamesImages} />);
+    expect(screen.getByText('World Of Winfield')).toBeInTheDocument();
+  });
+
+  it('renders 16 blocks, one per character in "WORLD OFWINFIELD"', () => {
+    const { container } = render(<Intro jamesImages={mockJamesImages} />);
+    // section > div (GridContainer) > div (Block) x 16
+    const blocks = container.querySelectorAll('section > div > div');
+    expect(blocks).toHaveLength(16);
+  });
+});

--- a/components/meta.test.tsx
+++ b/components/meta.test.tsx
@@ -75,6 +75,8 @@ describe('Meta', () => {
       />,
     );
     const canonical = findChild('link', (p) => p.rel === 'canonical');
-    expect(canonical?.props.href).toBe('https://www.worldofwinfield.co.uk/test-path');
+    expect((canonical?.props as { href?: string })?.href).toBe(
+      'https://www.worldofwinfield.co.uk/test-path',
+    );
   });
 });

--- a/components/meta.test.tsx
+++ b/components/meta.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import Meta from './meta';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ asPath: '/test-path' }),
+}));
+
+// Capture the React elements passed to Head so we can inspect them directly.
+// next/head requires its own React context to inject into document.head, so DOM
+// queries on document.head do not work in jsdom tests.
+let capturedChildren: React.ReactNode;
+
+jest.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => {
+    capturedChildren = children;
+    return null;
+  },
+}));
+
+function findChild(type: string, matcher: (props: Record<string, string>) => boolean) {
+  const children = React.Children.toArray(capturedChildren);
+  return children.find((child): child is React.ReactElement =>
+    React.isValidElement(child) && child.type === type && matcher(child.props as Record<string, string>),
+  );
+}
+
+describe('Meta', () => {
+  it('renders the title from the seo opengraphTitle', () => {
+    render(
+      <Meta
+        seo={{
+          opengraphTitle: 'SEO Page Title',
+          opengraphDescription: 'A description',
+          opengraphSiteName: 'World Of Winfield',
+        }}
+      />,
+    );
+    const titleEl = React.Children.toArray(capturedChildren).find(
+      (child): child is React.ReactElement =>
+        React.isValidElement(child) && child.type === 'title',
+    );
+    expect((titleEl?.props as { children?: string })?.children).toBe('SEO Page Title');
+  });
+
+  it('prefers the title prop over seo opengraphTitle', () => {
+    render(
+      <Meta
+        title="Custom Title"
+        seo={{
+          opengraphTitle: 'SEO Page Title',
+          opengraphDescription: 'A description',
+          opengraphSiteName: 'World Of Winfield',
+        }}
+      />,
+    );
+    const titleEl = React.Children.toArray(capturedChildren).find(
+      (child): child is React.ReactElement =>
+        React.isValidElement(child) && child.type === 'title',
+    );
+    expect((titleEl?.props as { children?: string })?.children).toBe('Custom Title');
+  });
+
+  it('renders a canonical link pointing to the current page URL', () => {
+    render(
+      <Meta
+        seo={{
+          opengraphTitle: 'Title',
+          opengraphDescription: 'Description',
+          opengraphSiteName: 'World Of Winfield',
+        }}
+      />,
+    );
+    const canonical = findChild('link', (p) => p.rel === 'canonical');
+    expect(canonical?.props.href).toBe('https://www.worldofwinfield.co.uk/test-path');
+  });
+});

--- a/components/meta.test.tsx
+++ b/components/meta.test.tsx
@@ -22,8 +22,11 @@ jest.mock('next/head', () => ({
 
 function findChild(type: string, matcher: (props: Record<string, string>) => boolean) {
   const children = React.Children.toArray(capturedChildren);
-  return children.find((child): child is React.ReactElement =>
-    React.isValidElement(child) && child.type === type && matcher(child.props as Record<string, string>),
+  return children.find(
+    (child): child is React.ReactElement =>
+      React.isValidElement(child) &&
+      child.type === type &&
+      matcher(child.props as Record<string, string>),
   );
 }
 
@@ -39,8 +42,7 @@ describe('Meta', () => {
       />,
     );
     const titleEl = React.Children.toArray(capturedChildren).find(
-      (child): child is React.ReactElement =>
-        React.isValidElement(child) && child.type === 'title',
+      (child): child is React.ReactElement => React.isValidElement(child) && child.type === 'title',
     );
     expect((titleEl?.props as { children?: string })?.children).toBe('SEO Page Title');
   });
@@ -57,8 +59,7 @@ describe('Meta', () => {
       />,
     );
     const titleEl = React.Children.toArray(capturedChildren).find(
-      (child): child is React.ReactElement =>
-        React.isValidElement(child) && child.type === 'title',
+      (child): child is React.ReactElement => React.isValidElement(child) && child.type === 'title',
     );
     expect((titleEl?.props as { children?: string })?.children).toBe('Custom Title');
   });

--- a/components/section-separator.test.tsx
+++ b/components/section-separator.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import SectionSeparator from './section-separator';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+describe('SectionSeparator', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<SectionSeparator />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders an hr element', () => {
+    const { container } = render(<SectionSeparator />);
+    expect(container.querySelector('hr')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- **SectionSeparator** — new test file covering the two key behaviours: renders without crashing and renders an `<hr>` element. Previously completely untested.
- **Intro** — new test file covering: renders a `<section>` element, renders the visually-hidden `<h1>` with "World Of Winfield", and renders 16 letter-blocks (one per character of "WORLD OFWINFIELD"). Previously completely untested.
- **Meta** — new test file covering: title comes from `seo.opengraphTitle` when no `title` prop is given, the `title` prop takes priority over `seo.opengraphTitle`, and the canonical `<link>` is constructed from the site base URL and `useRouter().asPath`. Previously completely untested.

## Notes

`next/head` requires its own runtime context and does not inject into `document.head` in a jsdom test environment. The Meta tests therefore mock `next/head` to capture the React element children it receives, then inspect those elements directly. This is the standard pattern for testing components that use `next/head` in unit tests.

## Test plan

- [x] `components/section-separator.test.tsx` — 2 tests pass
- [x] `components/intro.test.tsx` — 3 tests pass
- [x] `components/meta.test.tsx` — 3 tests pass
- [x] Full suite (200 tests) passes with no regressions

https://claude.ai/code/session_01S4pz69iwBm7agEKUuTa1Nv

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4pz69iwBm7agEKUuTa1Nv)_