### PR TITLE
chore(a11y): accessibility & SEO improvements — focus indicators, Twitter Cards, aria-controls, reduced-motion

### DIFF
--- a/components/core-components.tsx
+++ b/components/core-components.tsx
@@ -16,6 +16,11 @@ export const StyledButton = styled.button`
     color: ${colours.dark};
   }
 
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+
   @media (max-width: 768px) {
     flex: 1;
   }
@@ -26,6 +31,11 @@ export const StyledInput = styled.input`
   border: none;
   min-width: 100px;
   margin-bottom: 10px;
+
+  &:focus-visible {
+    outline: 2px solid ${colours.pink};
+    outline-offset: 2px;
+  }
 `;
 
 export const StyledSelect = styled.select`
@@ -33,4 +43,9 @@ export const StyledSelect = styled.select`
   border: none;
   min-width: 100px;
   margin-bottom: 10px;
+
+  &:focus-visible {
+    outline: 2px solid ${colours.pink};
+    outline-offset: 2px;
+  }
 `;

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -77,6 +77,11 @@ const RssLink = styled.a`
   &:hover {
     text-decoration: underline;
   }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.white};
+    outline-offset: 2px;
+  }
 `;
 
 const IconAttribution = styled.div`
@@ -85,5 +90,10 @@ const IconAttribution = styled.div`
   a {
     text-decoration: none;
     color: ${colours.white};
+
+    &:focus-visible {
+      outline: 2px solid ${colours.white};
+      outline-offset: 2px;
+    }
   }
 `;

--- a/components/intro.tsx
+++ b/components/intro.tsx
@@ -131,6 +131,10 @@ const Flipper = styled.div<FlipperProps>`
   transform-style: preserve-3d;
   width: 100%;
   height: 100%;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 `;
 
 const Front = styled.div`

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -82,7 +82,27 @@ export default function Meta({
       {opengraphImage?.mediaDetails?.height && (
         <meta property="og:image:height" content={opengraphImage.mediaDetails.height} />
       )}
-      {opengraphImage?.altText && <meta property="og:image:alt" content={opengraphImage.altText} />}
+      <meta
+        property="og:image:alt"
+        content={opengraphImage?.altText ? opengraphImage.altText : 'World Of Winfield'}
+      />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta
+        name="twitter:title"
+        content={opengraphTitle ? opengraphTitle : 'World Of Winfield - all about James Winfield'}
+      />
+      <meta
+        name="twitter:description"
+        content={
+          opengraphDescription
+            ? opengraphDescription
+            : 'World Of Winfield - all about James Winfield'
+        }
+      />
+      <meta
+        name="twitter:image"
+        content={opengraphImage?.mediaItemUrl ? opengraphImage.mediaItemUrl : defaultImageUrl}
+      />
       {ogType === 'article' && articleDate && (
         <meta property="article:published_time" content={articleDate} />
       )}

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -117,11 +117,13 @@ export default function Nav() {
                   toggleFavouritesDropdown();
                 }}
                 aria-label="Toggle Favourites submenu"
-                aria-expanded={isFavouritesDropdownOpen}>
+                aria-expanded={isFavouritesDropdownOpen}
+                aria-controls="favourites-menu">
                 ▼
               </DropdownArrow>
             </SplitButtonContainer>
             <DropdownMenu
+              id="favourites-menu"
               isDropdownOpen={isFavouritesDropdownOpen}
               aria-hidden={!isFavouritesDropdownOpen}>
               <li>
@@ -212,11 +214,13 @@ export default function Nav() {
                   toggleWishListDropdown();
                 }}
                 aria-label="Toggle Wish Lists submenu"
-                aria-expanded={isWishListDropdownOpen}>
+                aria-expanded={isWishListDropdownOpen}
+                aria-controls="wishlist-menu">
                 ▼
               </DropdownArrow>
             </SplitButtonContainer>
             <DropdownMenu
+              id="wishlist-menu"
               isDropdownOpen={isWishListDropdownOpen}
               aria-hidden={!isWishListDropdownOpen}>
               <li>
@@ -265,11 +269,15 @@ export default function Nav() {
                   toggleTravelDropdown();
                 }}
                 aria-label="Toggle Travel submenu"
-                aria-expanded={isTravelDropdownOpen}>
+                aria-expanded={isTravelDropdownOpen}
+                aria-controls="travel-menu">
                 ▼
               </DropdownArrow>
             </SplitButtonContainer>
-            <DropdownMenu isDropdownOpen={isTravelDropdownOpen} aria-hidden={!isTravelDropdownOpen}>
+            <DropdownMenu
+              id="travel-menu"
+              isDropdownOpen={isTravelDropdownOpen}
+              aria-hidden={!isTravelDropdownOpen}>
               <li>
                 <Link href="/countries-visited" onClick={closeNavOnMobile}>
                   Countries Visited
@@ -355,6 +363,11 @@ const NavList = styled.ul`
     color: #fff;
     text-decoration: none;
     font-size: 1.5rem;
+
+    &:focus-visible {
+      outline: 2px solid #fff;
+      outline-offset: 2px;
+    }
   }
 `;
 
@@ -395,6 +408,11 @@ const BurgerButton = styled.button`
     span:nth-of-type(3) {
       bottom: 0;
     }
+
+    &:focus-visible {
+      outline: 2px solid #fff;
+      outline-offset: 2px;
+    }
   }
 `;
 
@@ -411,6 +429,11 @@ const DropdownButton = styled.button`
   cursor: pointer;
   font-family: 'Oswald', sans-serif;
   letter-spacing: 2px;
+
+  &:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+  }
 `;
 
 const DropdownMenu = styled.ul<{ isDropdownOpen: boolean }>`
@@ -480,6 +503,12 @@ const DropdownArrow = styled.button`
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.1);
+    border-radius: 2px;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
     border-radius: 2px;
   }
 `;

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -95,6 +95,11 @@ const ImageLink = styled(Link)`
     width: 40%;
     aspect-ratio: 16 / 9;
   }
+
+  &:focus-visible {
+    outline: 2px solid #000;
+    outline-offset: 2px;
+  }
 `;
 
 const ColourFallback = styled.div<{ colour: string }>`
@@ -116,6 +121,11 @@ const ContentSide = styled.div`
 
 const TitleLink = styled(Link)`
   text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid #000;
+    outline-offset: 2px;
+  }
 `;
 
 const CardTitle = styled.h2`
@@ -153,6 +163,11 @@ const ReadMoreLink = styled(Link)`
 
   &:hover {
     background-color: ${colours.dark};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.pink};
+    outline-offset: 2px;
   }
 `;
 

--- a/components/share-bar.tsx
+++ b/components/share-bar.tsx
@@ -101,6 +101,11 @@ const buttonBase = `
   &:hover {
     opacity: 0.8;
   }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
 `;
 
 const ShareButton = styled.a`


### PR DESCRIPTION
## Summary

Thursday's scheduled accessibility & SEO audit found several issues across 7 components. This PR fixes the highest-impact ones.

### SEO — `components/meta.tsx`
- **Twitter Card tags added**: `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image` — the site previously had no Twitter/X social card support, so shared links showed no preview
- **`og:image:alt` always emitted**: previously only rendered when an image had alt text; now always present with a `'World Of Winfield'` fallback, as required by the OG spec

### Keyboard navigation — focus-visible outlines
All interactive elements previously had only `:hover` states, leaving keyboard-only and switch-access users with no visible focus indicator (WCAG 2.4.7 failure). Fixed across:
- **`core-components.tsx`**: `StyledButton`, `StyledInput`, `StyledSelect`
- **`nav.tsx`**: burger menu button, `DropdownButton`, `DropdownArrow`, and nav `<a>` links
- **`share-bar.tsx`**: shared button base styles (applies to both `ShareButton` and `CopyButton`)
- **`post-preview.tsx`**: `ImageLink`, `TitleLink`, `ReadMoreLink`
- **`footer.tsx`**: RSS link and icon attribution links

### ARIA — `components/nav.tsx`
- **`aria-controls` added** to each dropdown arrow button (`favourites-menu`, `wishlist-menu`, `travel-menu`), with matching `id` attributes on the corresponding `<DropdownMenu>` elements — assistive technologies can now programmatically associate the control with the region it expands

### Reduced motion — `components/intro.tsx`
- **`prefers-reduced-motion: reduce` media query** added to the card-flip `Flipper` animation — disables the 3D rotation transition for users who have requested reduced motion in their OS settings (WCAG 2.3.3)

## Test plan

- [ ] Tab through the navigation bar and confirm every button/link shows a white outline when focused
- [ ] Tab through a blog post page and confirm image link, title, and "Read More" button all show focus rings
- [ ] Tab through the share bar and confirm all share buttons and Copy Link show a focus ring
- [ ] Check the footer RSS and attribution links show focus rings
- [ ] Share a post URL on Twitter/X and confirm a summary card with title, description, and image appears
- [ ] In browser dev tools, enable `prefers-reduced-motion: reduce` and confirm the intro grid tiles no longer animate on hover
- [ ] Inspect page source and confirm `og:image:alt` is always present

https://claude.ai/code/session_01PKzd1Tf4xg12BfM5NDn3dx

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKzd1Tf4xg12BfM5NDn3dx)_