### PR TITLE
perf: convert countries-visited to ISR with 24h revalidation

### DIFF
--- a/pages/countries-visited.tsx
+++ b/pages/countries-visited.tsx
@@ -212,7 +212,7 @@ const ContentContainer = styled.section`
   }
 `;
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const rawData = await fetchDataFromGoogleSheets();
   const transformedData = rawData ? processData(rawData) : {};
 
@@ -220,5 +220,6 @@ export async function getServerSideProps() {
     props: {
       transformedData,
     },
+    revalidate: 86400,
   };
 }


### PR DESCRIPTION
## Summary

- Replaces `getServerSideProps` with `getStaticProps` + `revalidate: 86400` on the Countries Visited page
- Page is now statically generated at build time and silently revalidated at most once per day
- Eliminates a live Google Sheets API call on every page request

## Expected impact

TTFB drops from ~300–600 ms (Google Sheets round-trip) to < 50 ms (CDN edge cache hit) for the vast majority of visits.

Closes #415

## Test plan

- [ ] Visit `/countries-visited` and confirm the page loads correctly
- [ ] Confirm country data is displayed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)