### PR TITLE
feat: add 'Read this post' CTA buttons to section pages

### DIFF
--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import Layout from '../components/layout';
@@ -44,9 +45,13 @@ export default function Post({ posts }: PostsProps) {
                     heroPost={index === 0 || index === 1 ? true : false}
                   />
                 </StyledPostHeader>
-                <StyledExcerpt
-                  dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
-                  backgroundColour={colours.dark}></StyledExcerpt>
+                <ExcerptArea>
+                  <StyledExcerpt
+                    dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
+                    backgroundColour={colours.dark}
+                  />
+                  <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>
+                </ExcerptArea>
               </PostContainer>
             ))}
           </>
@@ -67,21 +72,44 @@ export const getStaticProps: GetStaticProps = async () => {
   };
 };
 
-const StyledExcerpt = styled.div<{ backgroundColour: string }>`
-  font-size: 1.2rem;
-  line-height: 1.5;
-  margin: 4rem auto;
+const ExcerptArea = styled.div`
   width: calc(50% - 4rem);
-  border-top: 5px solid ${(props) => props.backgroundColour};
+  margin: 4rem auto;
 
   @media screen and (max-width: 768px) {
     width: 100%;
     margin: 0 1rem;
+  }
+`;
+
+const StyledExcerpt = styled.div<{ backgroundColour: string }>`
+  font-size: 1.2rem;
+  line-height: 1.5;
+  border-top: 5px solid ${(props) => props.backgroundColour};
+
+  @media screen and (max-width: 768px) {
     border: none;
 
     p {
       margin: 1rem;
     }
+  }
+`;
+
+const ReadMoreLink = styled(Link)`
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 10px;
+  font-size: 1rem;
+  min-width: 100px;
+  background-color: ${colours.azure};
+  color: ${colours.white};
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
+
+  &:hover {
+    opacity: 0.85;
   }
 `;
 

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -51,7 +51,9 @@ export default function Post({ posts }: PostsProps) {
                 </StyledPostHeader>
                 <ExcerptArea>
                   <StyledExcerpt
-                    dangerouslySetInnerHTML={{ __html: sanitize(stripReadMoreParagraph(post.excerpt)) }}
+                    dangerouslySetInnerHTML={{
+                      __html: sanitize(stripReadMoreParagraph(post.excerpt)),
+                    }}
                     backgroundColour={colours.dark}
                   />
                   <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -12,6 +12,10 @@ import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
+const stripReadMoreParagraph = (excerpt: string) => {
+  return excerpt.replace(/\s*<a\b[^>]*>.*?<\/a>/gi, '').trim();
+};
+
 const goalsSeo = {
   opengraphTitle: 'Posts About Goals | World Of Winfield',
   opengraphDescription: 'A collection of posts about goals from World Of Winfield.',
@@ -47,7 +51,7 @@ export default function Post({ posts }: PostsProps) {
                 </StyledPostHeader>
                 <ExcerptArea>
                   <StyledExcerpt
-                    dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
+                    dangerouslySetInnerHTML={{ __html: sanitize(stripReadMoreParagraph(post.excerpt)) }}
                     backgroundColour={colours.dark}
                   />
                   <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -12,6 +12,10 @@ import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
+const stripReadMoreParagraph = (excerpt: string) => {
+  return excerpt.replace(/\s*<a\b[^>]*>.*?<\/a>/gi, '').trim();
+};
+
 const musicSeo = {
   opengraphTitle: 'Posts About Music | World Of Winfield',
   opengraphDescription: 'A collection of posts about music from World Of Winfield.',
@@ -47,7 +51,7 @@ export default function Post({ posts }: PostsProps) {
                 </StyledPostHeader>
                 <ExcerptArea>
                   <StyledExcerpt
-                    dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
+                    dangerouslySetInnerHTML={{ __html: sanitize(stripReadMoreParagraph(post.excerpt)) }}
                     backgroundColour={colours.dark}
                   />
                   <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -51,7 +51,9 @@ export default function Post({ posts }: PostsProps) {
                 </StyledPostHeader>
                 <ExcerptArea>
                   <StyledExcerpt
-                    dangerouslySetInnerHTML={{ __html: sanitize(stripReadMoreParagraph(post.excerpt)) }}
+                    dangerouslySetInnerHTML={{
+                      __html: sanitize(stripReadMoreParagraph(post.excerpt)),
+                    }}
                     backgroundColour={colours.dark}
                   />
                   <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import Layout from '../components/layout';
@@ -44,9 +45,13 @@ export default function Post({ posts }: PostsProps) {
                     heroPost={index === 0 || index === 1 ? true : false}
                   />
                 </StyledPostHeader>
-                <StyledExcerpt
-                  dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
-                  backgroundColour={colours.dark}></StyledExcerpt>
+                <ExcerptArea>
+                  <StyledExcerpt
+                    dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
+                    backgroundColour={colours.dark}
+                  />
+                  <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>
+                </ExcerptArea>
               </PostContainer>
             ))}
           </>
@@ -67,21 +72,44 @@ export const getStaticProps: GetStaticProps = async () => {
   };
 };
 
-const StyledExcerpt = styled.div<{ backgroundColour: string }>`
-  font-size: 1.2rem;
-  line-height: 1.5;
-  margin: 4rem auto;
+const ExcerptArea = styled.div`
   width: calc(50% - 4rem);
-  border-top: 5px solid ${(props) => props.backgroundColour};
+  margin: 4rem auto;
 
   @media screen and (max-width: 768px) {
     width: 100%;
     margin: 0 1rem;
+  }
+`;
+
+const StyledExcerpt = styled.div<{ backgroundColour: string }>`
+  font-size: 1.2rem;
+  line-height: 1.5;
+  border-top: 5px solid ${(props) => props.backgroundColour};
+
+  @media screen and (max-width: 768px) {
     border: none;
 
     p {
       margin: 1rem;
     }
+  }
+`;
+
+const ReadMoreLink = styled(Link)`
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 10px;
+  font-size: 1rem;
+  min-width: 100px;
+  background-color: ${colours.purple};
+  color: ${colours.white};
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
+
+  &:hover {
+    opacity: 0.85;
   }
 `;
 

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -12,6 +12,10 @@ import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
+const stripReadMoreParagraph = (excerpt: string) => {
+  return excerpt.replace(/\s*<a\b[^>]*>.*?<\/a>/gi, '').trim();
+};
+
 const politicsSeo = {
   opengraphTitle: 'Posts About Politics | World Of Winfield',
   opengraphDescription: 'A collection of posts about politics from World Of Winfield.',
@@ -47,7 +51,7 @@ export default function Post({ posts }: PostsProps) {
                 </StyledPostHeader>
                 <ExcerptArea>
                   <StyledExcerpt
-                    dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
+                    dangerouslySetInnerHTML={{ __html: sanitize(stripReadMoreParagraph(post.excerpt)) }}
                     backgroundColour={colours.dark}
                   />
                   <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -51,7 +51,9 @@ export default function Post({ posts }: PostsProps) {
                 </StyledPostHeader>
                 <ExcerptArea>
                   <StyledExcerpt
-                    dangerouslySetInnerHTML={{ __html: sanitize(stripReadMoreParagraph(post.excerpt)) }}
+                    dangerouslySetInnerHTML={{
+                      __html: sanitize(stripReadMoreParagraph(post.excerpt)),
+                    }}
                     backgroundColour={colours.dark}
                   />
                   <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import Layout from '../components/layout';
@@ -44,9 +45,13 @@ export default function Post({ posts }: PostsProps) {
                     heroPost={index === 0 || index === 1 ? true : false}
                   />
                 </StyledPostHeader>
-                <StyledExcerpt
-                  dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
-                  backgroundColour={colours.dark}></StyledExcerpt>
+                <ExcerptArea>
+                  <StyledExcerpt
+                    dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
+                    backgroundColour={colours.dark}
+                  />
+                  <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>
+                </ExcerptArea>
               </PostContainer>
             ))}
           </>
@@ -67,21 +72,44 @@ export const getStaticProps: GetStaticProps = async () => {
   };
 };
 
-const StyledExcerpt = styled.div<{ backgroundColour: string }>`
-  font-size: 1.2rem;
-  line-height: 1.5;
-  margin: 4rem auto;
+const ExcerptArea = styled.div`
   width: calc(50% - 4rem);
-  border-top: 5px solid ${(props) => props.backgroundColour};
+  margin: 4rem auto;
 
   @media screen and (max-width: 768px) {
     width: 100%;
     margin: 0 1rem;
+  }
+`;
+
+const StyledExcerpt = styled.div<{ backgroundColour: string }>`
+  font-size: 1.2rem;
+  line-height: 1.5;
+  border-top: 5px solid ${(props) => props.backgroundColour};
+
+  @media screen and (max-width: 768px) {
     border: none;
 
     p {
       margin: 1rem;
     }
+  }
+`;
+
+const ReadMoreLink = styled(Link)`
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 10px;
+  font-size: 1rem;
+  min-width: 100px;
+  background-color: ${colours.burgandy};
+  color: ${colours.white};
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
+
+  &:hover {
+    opacity: 0.85;
   }
 `;
 

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -52,7 +52,9 @@ export default function Post({ posts }: PostsProps) {
                 </StyledPostHeader>
                 <ExcerptArea>
                   <StyledExcerpt
-                    dangerouslySetInnerHTML={{ __html: sanitize(stripReadMoreParagraph(post.excerpt)) }}
+                    dangerouslySetInnerHTML={{
+                      __html: sanitize(stripReadMoreParagraph(post.excerpt)),
+                    }}
                     backgroundColour={colours.dark}
                   />
                   <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import Layout from '../components/layout';
@@ -45,9 +46,13 @@ export default function Post({ posts }: PostsProps) {
                     heroPost={index === 0 || index === 1 ? true : false}
                   />
                 </StyledPostHeader>
-                <StyledExcerpt
-                  dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
-                  backgroundColour={colours.dark}></StyledExcerpt>
+                <ExcerptArea>
+                  <StyledExcerpt
+                    dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
+                    backgroundColour={colours.dark}
+                  />
+                  <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>
+                </ExcerptArea>
               </PostContainer>
             ))}
           </>
@@ -68,21 +73,44 @@ export const getStaticProps: GetStaticProps = async () => {
   };
 };
 
-const StyledExcerpt = styled.div<{ backgroundColour: string }>`
-  font-size: 1.2rem;
-  line-height: 1.5;
-  margin: 4rem auto;
+const ExcerptArea = styled.div`
   width: calc(50% - 4rem);
-  border-top: 5px solid ${(props) => props.backgroundColour};
+  margin: 4rem auto;
 
   @media screen and (max-width: 768px) {
     width: 100%;
     margin: 0 1rem;
+  }
+`;
+
+const StyledExcerpt = styled.div<{ backgroundColour: string }>`
+  font-size: 1.2rem;
+  line-height: 1.5;
+  border-top: 5px solid ${(props) => props.backgroundColour};
+
+  @media screen and (max-width: 768px) {
     border: none;
 
     p {
       margin: 1rem;
     }
+  }
+`;
+
+const ReadMoreLink = styled(Link)`
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 10px;
+  font-size: 1rem;
+  min-width: 100px;
+  background-color: ${colours.green};
+  color: ${colours.white};
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
+
+  &:hover {
+    opacity: 0.85;
   }
 `;
 

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -12,6 +12,10 @@ import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
+const stripReadMoreParagraph = (excerpt: string) => {
+  return excerpt.replace(/\s*<a\b[^>]*>.*?<\/a>/gi, '').trim();
+};
+
 const travelSeo = {
   opengraphTitle: 'Posts About Travel | World Of Winfield',
   opengraphDescription: 'A collection of posts about travel from World Of Winfield.',
@@ -48,7 +52,7 @@ export default function Post({ posts }: PostsProps) {
                 </StyledPostHeader>
                 <ExcerptArea>
                   <StyledExcerpt
-                    dangerouslySetInnerHTML={{ __html: sanitize(post.excerpt) }}
+                    dangerouslySetInnerHTML={{ __html: sanitize(stripReadMoreParagraph(post.excerpt)) }}
                     backgroundColour={colours.dark}
                   />
                   <ReadMoreLink href={`/${post.slug}`}>Read this post →</ReadMoreLink>


### PR DESCRIPTION
## Summary

- Adds a `ReadMoreLink` button beneath each post excerpt on `/music`, `/travel`, `/goals`, and `/politics`
- Each section gets a themed colour (purple/green/azure/burgandy) matching homepage block colours
- Excerpt + CTA are wrapped in an `ExcerptArea` div to keep both in the correct flex column
- No new data fetching — `post.slug` was already in scope on all four pages

Closes #412

## Test plan

- [ ] Visit `/music` — verify "Read this post →" appears below each excerpt in purple
- [ ] Visit `/travel` — verify CTA appears in green
- [ ] Visit `/goals` — verify CTA appears in azure/blue
- [ ] Visit `/politics` — verify CTA appears in burgandy
- [ ] Click a CTA and confirm it navigates to the correct post slug
- [ ] Check mobile layout — excerpt area should stack correctly at ≤768px

🤖 Generated with [Claude Code](https://claude.com/claude-code)