### PR TITLE
chore(typescript): convert interfaces to type aliases and add explicit return types

### DIFF
--- a/components/archive.tsx
+++ b/components/archive.tsx
@@ -17,7 +17,7 @@ const ArchiveDropdown = () => {
     },
   );
 
-  const handleSelectMonth = async (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleSelectMonth = async (event: React.ChangeEvent<HTMLSelectElement>): Promise<void> => {
     const selectedValue = event.target.value;
 
     if (selectedValue) {

--- a/components/cover-image.tsx
+++ b/components/cover-image.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
 
-interface Props {
+type Props = {
   title: string;
   coverImage?: {
     node: {
@@ -18,7 +18,7 @@ interface Props {
   imageSize?: string;
   slug?: string;
   heroPost?: boolean;
-}
+};
 
 export default function CoverImage({ title, coverImage, imageSize, slug, heroPost }: Props) {
   const image = coverImage?.node.sourceUrl && (

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -14,7 +14,7 @@ const SearchBar = ({ onSearch }: SearchBarProps) => {
     setQuery(e.target.value);
   };
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
     setLoading(true);
     const searchResults = await searchBlogPosts(query);

--- a/components/share-bar.tsx
+++ b/components/share-bar.tsx
@@ -20,7 +20,7 @@ export default function ShareBar({ title, url }: ShareBarProps) {
   const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
   const whatsappUrl = `https://wa.me/?text=${encodedTitle}%20${encodedUrl}`;
 
-  const handleCopy = async () => {
+  const handleCopy = async (): Promise<void> => {
     await navigator.clipboard.writeText(url);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -5,9 +5,9 @@ import Container from '../components/container';
 import Layout from '../components/layout';
 import { colours } from '../pages/_app';
 
-interface BlockProps {
+type BlockProps = {
   backgroundColour: string;
-}
+};
 
 const baseColours = [
   colours.pink,

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -21,7 +21,7 @@ export default function Index({ allPosts, preview }: IndexPageProps) {
     setSearchResults(results);
   };
 
-  const loadMorePosts = async () => {
+  const loadMorePosts = async (): Promise<void> => {
     setIsLoading(true);
     const res = await fetch(`/api/blog-posts?after=${endCursor}`);
     const data = await res.json();

--- a/pages/favourites-results.tsx
+++ b/pages/favourites-results.tsx
@@ -29,7 +29,7 @@ const FavouriteResults = ({
   const showInternalDropdown = sortBy === undefined;
 
   useEffect(() => {
-    const fetchFavouriteData = async () => {
+    const fetchFavouriteData = async (): Promise<void> => {
       if (sheetId && !loading) {
         setLoading(true);
         try {

--- a/pages/favourites.tsx
+++ b/pages/favourites.tsx
@@ -80,7 +80,7 @@ export default function FavouritesHubPage() {
   const [counts, setCounts] = useState<Record<string, number | null>>({});
 
   useEffect(() => {
-    const fetchCounts = async () => {
+    const fetchCounts = async (): Promise<void> => {
       const results = await Promise.all(
         categories.map(async ({ title, sheetId }) => {
           const data = await fetchDataFromGoogleSheets(sheetId);

--- a/pages/stats.tsx
+++ b/pages/stats.tsx
@@ -53,7 +53,7 @@ const parseCountriesData = (
   return { visited, total, continents: continentsVisited.size };
 };
 
-interface StatsProps {
+type StatsProps = {
   countriesVisited: number;
   totalCountries: number;
   continentsVisited: number;
@@ -68,7 +68,7 @@ interface StatsProps {
   cities: number;
   favouriteCountries: number;
   totalPosts: number;
-}
+};
 
 export default function Stats({
   countriesVisited,


### PR DESCRIPTION
## Summary

Monday TypeScript & typing pass. Two categories of fix across 9 files:

**1. `interface` → `type` aliases (3 files)**

The project convention (and the `prefer type` rule) is to use `type` aliases rather than `interface` unless declaration merging is required. Three interface declarations were converted:
- `pages/404.tsx` — `BlockProps`
- `pages/stats.tsx` — `StatsProps`
- `components/cover-image.tsx` — `Props`

**2. Explicit `Promise<void>` return types on async handlers (6 files)**

Six async functions were missing explicit return type annotations. Adding `Promise<void>` makes the intent clear and helps TypeScript catch accidental implicit `return value` in void handlers:
- `pages/blog.tsx` — `loadMorePosts`
- `pages/favourites.tsx` — `fetchCounts`
- `pages/favourites-results.tsx` — `fetchFavouriteData`
- `components/share-bar.tsx` — `handleCopy`
- `components/archive.tsx` — `handleSelectMonth`
- `components/search-bar.tsx` — `handleSubmit`

## Test plan
- [ ] `tsc --noEmit` passes with no new errors
- [ ] Pages render correctly: 404, /stats, /blog, /favourites, /favourites-results pages
- [ ] Share bar copy button, archive dropdown, and search bar all function as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGWFEHDcJiDKE7XZbktKG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGWFEHDcJiDKE7XZbktKG2)_