### PR TITLE
feat: add /tags index page

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
 import { colours } from '../pages/_app';
 import ArchiveDropdown from './archive';
 import Container from './container';
@@ -11,6 +12,7 @@ export default function Footer() {
           <FlexRow>
             <ArchiveDropdown />
             <p>World Of Winfield</p>
+            <BrowseTopicsLink href="/tags">Browse all topics</BrowseTopicsLink>
             <RssLink href="/api/feed">Subscribe via RSS</RssLink>
           </FlexRow>
           <IconAttribution>
@@ -64,6 +66,23 @@ const FlexRow = styled.div`
 
   @media screen and (max-width: 768px) {
     flex-direction: column;
+  }
+`;
+
+const BrowseTopicsLink = styled(Link)`
+  color: ${colours.white};
+  text-decoration: none;
+  font-size: 1rem;
+  letter-spacing: 1px;
+  align-self: center;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.white};
+    outline-offset: 2px;
   }
 `;
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -601,6 +601,24 @@ export async function getRandomImage(randomMonth: number, randomYear: number) {
   };
 }
 
+export async function getAllTags(): Promise<{ name: string; count: number }[]> {
+  const data = await fetchAPI(`
+    {
+      tags(first: 100) {
+        nodes {
+          name
+          count
+        }
+      }
+    }
+  `);
+  return (data?.tags?.nodes ?? [])
+    .filter((tag: { name: string; count: number | null }) => tag.count && tag.count > 0)
+    .sort(
+      (a: { name: string; count: number }, b: { name: string; count: number }) => b.count - a.count,
+    );
+}
+
 export async function getTotalPostCount(): Promise<number> {
   try {
     const res = await fetch('https://blog.worldofwinfield.co.uk/wp-json/wp/v2/posts?per_page=1');

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -510,3 +510,7 @@ export type ArchivePageProps = {
   month: number;
   year: number;
 };
+
+export type TagIndexPageProps = {
+  tags: { name: string; count: number }[];
+};

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { GetStaticProps } from 'next';
+import Link from 'next/link';
 import { useState } from 'react';
 import Container from '../components/container';
 import HeroPost from '../components/hero-post';
@@ -63,6 +64,9 @@ export default function Index({ allPosts, preview }: IndexPageProps) {
           </LoadMoreContainer>
         )}
       </Container>
+      <BrowseTopicsBar>
+        <Link href="/tags">Browse all topics →</Link>
+      </BrowseTopicsBar>
       <SearchBar onSearch={handleSearch} />
       <SearchResults searchResults={searchResults} />
     </Layout>
@@ -77,6 +81,22 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
     revalidate: 3600,
   };
 };
+
+const BrowseTopicsBar = styled.div`
+  text-align: center;
+  padding: 1rem 0;
+
+  a {
+    font-size: 1rem;
+    color: #000;
+    text-decoration: none;
+    font-weight: 600;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
 
 const LoadMoreContainer = styled.div`
   display: flex;

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -25,6 +25,8 @@ const blockColours = [
   colours.blueish,
 ];
 
+const lightBackgrounds = new Set([colours.purple, colours.green, colours.blueish, colours.azure]);
+
 const getColourFromTitle = (title: string) => {
   let hash = 0;
   for (let i = 0; i < title.length; i++) {
@@ -32,6 +34,8 @@ const getColourFromTitle = (title: string) => {
   }
   return blockColours[Math.abs(hash) % blockColours.length];
 };
+
+const getTextColour = (bg: string) => (lightBackgrounds.has(bg) ? colours.dark : colours.white);
 
 const stripReadMoreParagraph = (excerpt: string) => {
   return excerpt.replace(/\s*<a\b[^>]*>.*?<\/a>/gi, '').trim();
@@ -91,7 +95,8 @@ export default function Post({ posts, tag }: TagsPostProps) {
                       )}
                       <ContinueReadingLink
                         href={`/${post.slug}`}
-                        colour={getColourFromTitle(post.title)}>
+                        colour={getColourFromTitle(post.title)}
+                        textcolour={getTextColour(getColourFromTitle(post.title))}>
                         Continue reading
                       </ContinueReadingLink>
                     </TagPostContent>
@@ -182,13 +187,13 @@ const TagPostExcerpt = styled.div`
   }
 `;
 
-const ContinueReadingLink = styled(Link)<{ colour: string }>`
+const ContinueReadingLink = styled(Link)<{ colour: string; textcolour: string }>`
   display: inline-block;
   padding: 10px;
   font-size: 1rem;
   min-width: 100px;
   background-color: ${(props) => props.colour};
-  color: ${colours.white};
+  color: ${(props) => props.textcolour};
   font-weight: bold;
   text-decoration: none;
   text-align: center;

--- a/pages/tags/index.tsx
+++ b/pages/tags/index.tsx
@@ -1,0 +1,116 @@
+import styled from '@emotion/styled';
+import { GetStaticProps } from 'next';
+import Link from 'next/link';
+import Container from '../../components/container';
+import Layout from '../../components/layout';
+import PostHeader from '../../components/post-header';
+import { getAllTags } from '../../lib/api';
+import { TagIndexPageProps } from '../../lib/types';
+import { colours } from '../_app';
+
+const blockColours = [
+  colours.pink,
+  colours.green,
+  colours.purple,
+  colours.burgandy,
+  colours.azure,
+  colours.blueish,
+  colours.dark,
+];
+
+const lightBackgrounds = new Set([colours.purple, colours.green, colours.blueish, colours.azure]);
+
+const getColourFromName = (name: string) => {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) & 0xffffffff;
+  }
+  return blockColours[Math.abs(hash) % blockColours.length];
+};
+
+const getTextColour = (bg: string) => (lightBackgrounds.has(bg) ? colours.dark : colours.white);
+
+export default function TagsIndex({ tags }: TagIndexPageProps) {
+  const seo = {
+    opengraphTitle: 'Browse All Topics - World Of Winfield',
+    opengraphDescription: 'Browse all topics covered on World Of Winfield',
+    opengraphSiteName: 'World Of Winfield',
+    opengraphImage: undefined,
+  };
+
+  return (
+    <Layout preview={null} seo={seo} title="Browse All Topics">
+      <Container>
+        <PostHeader title="Browse All Topics" />
+        <TagGrid>
+          {tags.map((tag) => {
+            const bg = getColourFromName(tag.name);
+            return (
+              <TagTile
+                key={tag.name}
+                href={`/tags/${encodeURIComponent(tag.name)}`}
+                colour={bg}
+                textcolour={getTextColour(bg)}>
+                <TagName>{tag.name}</TagName>
+                <TagCount>
+                  {tag.count} {tag.count === 1 ? 'post' : 'posts'}
+                </TagCount>
+              </TagTile>
+            );
+          })}
+        </TagGrid>
+      </Container>
+    </Layout>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const tags = await getAllTags();
+
+  return {
+    props: { tags },
+    revalidate: 3600,
+  };
+};
+
+const TagGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  padding: 2rem 0;
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+`;
+
+const TagTile = styled(Link)<{ colour: string; textcolour: string }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: ${(props) => props.colour};
+  color: ${(props) => props.textcolour};
+  text-decoration: none;
+  padding: 1.5rem 1rem;
+  min-height: 100px;
+  text-align: center;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 0.85;
+  }
+`;
+
+const TagName = styled.span`
+  font-family: 'Oswald', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: capitalize;
+`;
+
+const TagCount = styled.span`
+  font-size: 0.9rem;
+  margin-top: 0.4rem;
+`;


### PR DESCRIPTION
## Summary

- Adds a `/tags` index page listing every tag as a colour-coded tile sorted by post count, using the existing site palette and `getStaticProps` with ISR (revalidate 3600)
- Adds `getAllTags()` to `lib/api.ts` via the WordPress GraphQL `tags` query
- Adds "Browse all topics" link to the blog page and footer
- Fixes WCAG colour contrast: dark text (`#291720`) is used on light-background colours (purple, green, blueish, azure) on both the new tag index tiles and the existing "Continue reading" buttons on `/tags/[tag]`

## Test plan

- [ ] Visit `/tags` — grid of colour-coded tiles renders, sorted by post count
- [ ] Click a tile — navigates to the correct `/tags/[tag]` page
- [ ] Check "Browse all topics" link appears on `/blog` and in the footer
- [ ] Run an axe/accented accessibility check — no colour-contrast failures on tag tiles or continue-reading buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)