### PR TITLE
test: add tests for HomepageBlock and fetchDataFromGoogleSheets

### DIFF
--- a/components/homepage-block.test.tsx
+++ b/components/homepage-block.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import { JamesImagesProps } from '../lib/types';
+import HomepageBlock from './homepage-block';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+jest.mock('./search-results', () => ({
+  formatDate: (date: string) => date,
+}));
+
+const mockJamesImages: JamesImagesProps = {
+  edges: [
+    {
+      node: {
+        title: 'james image',
+        featuredImage: {
+          node: {
+            mediaDetails: { height: 100, width: 100, sizes: '' },
+            sourceUrl: 'https://example.com/james.jpg',
+            srcset: '',
+          },
+        },
+      },
+    },
+  ],
+};
+
+describe('HomepageBlock', () => {
+  beforeEach(() => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders the icon image when icon prop is provided', () => {
+    const { container } = render(
+      <HomepageBlock
+        title="Music"
+        url="/music"
+        size={2}
+        jamesImages={mockJamesImages}
+        icon="004-record"
+      />,
+    );
+    expect(container.querySelector('img')).toHaveAttribute('src', '/icons/004-record.png');
+  });
+
+  it('renders a link with the correct aria-label and href when url is provided', () => {
+    render(
+      <HomepageBlock
+        title="Latest Post"
+        url="/latest-post"
+        size={1}
+        jamesImages={mockJamesImages}
+        image={{ node: { sourceUrl: 'https://example.com/post.jpg' } }}
+      />,
+    );
+    expect(screen.getByRole('link', { name: 'Latest Post' })).toHaveAttribute(
+      'href',
+      '/latest-post',
+    );
+  });
+
+  it('shows a label badge when the label prop is provided', () => {
+    render(
+      <HomepageBlock
+        title="Old Post"
+        url="/old-post"
+        size={2}
+        jamesImages={mockJamesImages}
+        label="5 years ago"
+      />,
+    );
+    expect(screen.getByText('5 years ago')).toBeInTheDocument();
+  });
+
+  it('does not show a label badge when label prop is omitted', () => {
+    render(
+      <HomepageBlock
+        title="Recent Post"
+        url="/recent-post"
+        size={2}
+        jamesImages={mockJamesImages}
+      />,
+    );
+    expect(screen.queryByText(/years ago/)).not.toBeInTheDocument();
+  });
+
+  it('renders the post title and date in the overlay when both url and date are provided', () => {
+    render(
+      <HomepageBlock
+        title="My Blog Post"
+        url="/my-blog-post"
+        size={3}
+        date="2023-01-15"
+        jamesImages={mockJamesImages}
+        image={{ node: { sourceUrl: 'https://example.com/post.jpg' } }}
+      />,
+    );
+    expect(screen.getByText('My Blog Post')).toBeInTheDocument();
+    expect(screen.getByText('2023-01-15')).toBeInTheDocument();
+  });
+});

--- a/lib/sheets.test.ts
+++ b/lib/sheets.test.ts
@@ -1,0 +1,50 @@
+import { fetchDataFromGoogleSheets } from './sheets';
+
+const SHEET_ID = 'test-sheet-123';
+const API_KEY = 'test-api-key';
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY = API_KEY;
+  mockFetch.mockReset();
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+describe('fetchDataFromGoogleSheets', () => {
+  it('returns the values array from a successful response', async () => {
+    const mockValues = [
+      ['Header1', 'Header2'],
+      ['Row1Col1', 'Row1Col2'],
+    ];
+    mockFetch.mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ values: mockValues }),
+    });
+
+    const result = await fetchDataFromGoogleSheets(SHEET_ID);
+
+    expect(result).toEqual(mockValues);
+  });
+
+  it('constructs the correct URL using the sheet ID and API key', async () => {
+    mockFetch.mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ values: [] }),
+    });
+
+    await fetchDataFromGoogleSheets(SHEET_ID);
+
+    const expectedUrl = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/Sheet1?alt=json&key=${API_KEY}`;
+    expect(mockFetch).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  it('returns null and logs an error when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network failure'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await fetchDataFromGoogleSheets(SHEET_ID);
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- **`components/homepage-block.test.tsx`** (new, 5 tests): `HomepageBlock` was the only component without any test coverage. Tests cover the icon variant, the image-link variant with correct `aria-label`/`href`, the label badge (present and absent), and the title+date overlay rendered when both `url` and `date` are provided.
- **`lib/sheets.test.ts`** (new, 3 tests): `fetchDataFromGoogleSheets` had no tests. Tests verify the returned values on a successful response, that the correct Google Sheets API URL is constructed from the `sheetID` and API key, and that the function returns `null` (without throwing) when `fetch` rejects.

## Why

Today's focus category is **Tests** (Tuesday). These were the two highest-value untested files — `HomepageBlock` is the only component lacking coverage, and `sheets.ts` is a utility with external API calls and an error-handling path that was completely untested.

## Test plan

- [x] All 8 new tests pass locally (`yarn jest lib/sheets.test.ts components/homepage-block.test.tsx --no-coverage`)
- [x] No existing tests modified

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fd61DZytAhPS5f36nRZq4k)_