### PR TITLE
feat(share): add ShareBar to /now and all favourites pages

### DIFF
--- a/pages/favourite-articles.tsx
+++ b/pages/favourite-articles.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Articles Read';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-beers.tsx
+++ b/pages/favourite-beers.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Beer';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-books.tsx
+++ b/pages/favourite-books.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Books';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-cheese.tsx
+++ b/pages/favourite-cheese.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Cheese';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-cities.tsx
+++ b/pages/favourite-cities.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Cities Visited';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-countries.tsx
+++ b/pages/favourite-countries.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Countries Visited';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-djs.tsx
+++ b/pages/favourite-djs.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite DJs';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-movies.tsx
+++ b/pages/favourite-movies.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Movies';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-restaurants.tsx
+++ b/pages/favourite-restaurants.tsx
@@ -5,6 +5,7 @@ import FavouritesHubLink from '../components/favourites-hub-link';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 export default function FavouritesPage() {
   const title = 'Favourite Restaurants';
@@ -36,6 +37,7 @@ export default function FavouritesPage() {
               </StyledPostHeader>
 
               <FavouriteResults sheetId={sheetId} />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/favourite-tracks.tsx
+++ b/pages/favourite-tracks.tsx
@@ -7,6 +7,7 @@ import GenreDropdown from '../components/GenreDropdown';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import ShareBar from '../components/share-bar';
 import FavouriteResults from './favourites-results';
 
 export default function FavouritesPage() {
@@ -115,6 +116,7 @@ export default function FavouritesPage() {
                 genreFilter={selectedGenre}
                 labelFilter={selectedLabel}
               />
+              <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
           </>

--- a/pages/now.tsx
+++ b/pages/now.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import Container from '../components/container';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
+import ShareBar from '../components/share-bar';
 import { NOW_LAST_UPDATED } from '../data/now-meta';
 import { colours } from './_app';
 
@@ -67,6 +68,11 @@ export default function NowPage() {
                 World Cup, but also FUCK TRUMP.
               </p>
             </Section>
+
+            <ShareBar
+              title="What I'm Up To Now — World Of Winfield"
+              url="https://worldofwinfield.co.uk/now"
+            />
 
             <Footer>
               <p>


### PR DESCRIPTION
## Summary

- Adds the existing `ShareBar` component (Threads, Bluesky, Facebook, WhatsApp, Copy Link) to `pages/now.tsx` and all 10 favourites pages
- `/now` uses a static title and URL; favourites pages use the existing `title` constant and `router.asPath` for the URL
- Zero new infrastructure — pure wiring of the already battle-tested component

Closes #444

## Test plan

- [ ] Visit `/now` and confirm ShareBar appears before the footer
- [ ] Visit a few favourites pages (e.g. `/favourite-movies`, `/favourite-tracks`) and confirm ShareBar appears between the results and the hub link
- [ ] Confirm share buttons open correct URLs with the right title and page URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)