### PR TITLE
feat(navigation): add Explore More related sections to topic pages

### DIFF
--- a/components/related-sections.tsx
+++ b/components/related-sections.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import Link from 'next/link';
+import { colours } from '../pages/_app';
+
+type RelatedSection = {
+  label: string;
+  href: string;
+  colour: string;
+};
+
+type RelatedSectionsProps = {
+  sections: RelatedSection[];
+};
+
+export default function RelatedSections({ sections }: RelatedSectionsProps) {
+  return (
+    <Wrapper>
+      <Heading>Explore more</Heading>
+      <TileRow>
+        {sections.map(({ label, href, colour }) => (
+          <Tile key={href} href={href} colour={colour}>
+            {label}
+          </Tile>
+        ))}
+      </TileRow>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.nav`
+  max-width: 1268px;
+  margin: 4rem auto 2rem;
+  padding: 0 1rem;
+`;
+
+const Heading = styled.h2`
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: ${colours.dark};
+`;
+
+const TileRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+const Tile = styled(Link)<{ colour: string }>`
+  display: inline-block;
+  padding: 1rem 1.5rem;
+  background-color: ${(props) => props.colour};
+  color: ${colours.white};
+  font-size: 1rem;
+  font-weight: bold;
+  text-decoration: none;
+  min-width: 160px;
+  text-align: center;
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  @media screen and (max-width: 768px) {
+    flex: 1 1 calc(50% - 0.5rem);
+    min-width: 0;
+  }
+`;

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -7,6 +7,7 @@ import Container from '../components/container';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import RelatedSections from '../components/related-sections';
 import { filterPostsByTag } from '../lib/api';
 import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
@@ -62,6 +63,12 @@ export default function Post({ posts }: PostsProps) {
             ))}
           </>
         )}
+        <RelatedSections
+          sections={[
+            { label: 'Now', href: '/now', colour: colours.azure },
+            { label: 'Wants', href: '/wants', colour: colours.green },
+          ]}
+        />
       </Container>
     </Layout>
   );

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -7,6 +7,7 @@ import Container from '../components/container';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import RelatedSections from '../components/related-sections';
 import { filterPostsByTag } from '../lib/api';
 import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
@@ -62,6 +63,12 @@ export default function Post({ posts }: PostsProps) {
             ))}
           </>
         )}
+        <RelatedSections
+          sections={[
+            { label: 'Favourite Tracks', href: '/favourite-tracks', colour: colours.purple },
+            { label: 'Favourite DJs', href: '/favourite-djs', colour: colours.pink },
+          ]}
+        />
       </Container>
     </Layout>
   );

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -7,6 +7,7 @@ import Container from '../components/container';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import RelatedSections from '../components/related-sections';
 import { filterPostsByTag } from '../lib/api';
 import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
@@ -62,6 +63,12 @@ export default function Post({ posts }: PostsProps) {
             ))}
           </>
         )}
+        <RelatedSections
+          sections={[
+            { label: 'Browse by Tag', href: '/tags', colour: colours.burgandy },
+            { label: 'All Posts', href: '/blog', colour: colours.dark },
+          ]}
+        />
       </Container>
     </Layout>
   );

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -7,6 +7,7 @@ import Container from '../components/container';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import RelatedSections from '../components/related-sections';
 import { filterPostsByTag } from '../lib/api';
 import { sanitize } from '../lib/sanitize';
 import { PostsProps } from '../lib/types';
@@ -63,6 +64,13 @@ export default function Post({ posts }: PostsProps) {
             ))}
           </>
         )}
+        <RelatedSections
+          sections={[
+            { label: 'Countries Visited', href: '/countries-visited', colour: colours.green },
+            { label: 'Favourite Cities', href: '/favourite-cities', colour: colours.blueish },
+            { label: 'Holiday Wish List', href: '/holiday-wish-list', colour: colours.azure },
+          ]}
+        />
       </Container>
     </Layout>
   );


### PR DESCRIPTION
## Summary

- Creates `components/related-sections.tsx` — a reusable component accepting `{ label, href, colour }[]` and rendering a row of coloured navigation tiles
- Adds an "Explore more" panel at the bottom of `/travel` (Countries Visited, Favourite Cities, Holiday Wish List), `/music` (Favourite Tracks, Favourite DJs), `/politics` (Browse by Tag, All Posts), and `/goals` (Now, Wants)
- Zero new data fetching — purely static cross-links reusing the existing `colours` palette

Closes #443

## Test plan

- [ ] Visit `/travel` — confirm "Explore more" tiles appear below the post list and link to `/countries-visited`, `/favourite-cities`, `/holiday-wish-list`
- [ ] Visit `/music` — confirm tiles link to `/favourite-tracks`, `/favourite-djs`
- [ ] Visit `/politics` — confirm tiles link to `/tags`, `/blog`
- [ ] Visit `/goals` — confirm tiles link to `/now`, `/wants`
- [ ] Check tile hover state (opacity reduction) works
- [ ] Check mobile layout (tiles wrap to 2-per-row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)