### PR TITLE
fix(a11y): label main nav landmark, wire burger aria-controls, fix archive nav labels

### DIFF
--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -59,16 +59,17 @@ export default function Nav() {
   };
 
   return (
-    <StyledNav>
+    <StyledNav aria-label="Main">
       <BurgerButton
         onClick={toggleDropdown}
         aria-label="Toggle navigation menu"
-        aria-expanded={isDropdownOpen}>
+        aria-expanded={isDropdownOpen}
+        aria-controls="main-nav-list">
         <span></span>
         <span></span>
         <span></span>
       </BurgerButton>
-      <NavList className={isDropdownOpen ? 'open' : ''}>
+      <NavList id="main-nav-list" className={isDropdownOpen ? 'open' : ''}>
         <li>
           <Link href="/" onClick={closeNavOnMobile}>
             Home

--- a/pages/archive-page.tsx
+++ b/pages/archive-page.tsx
@@ -29,12 +29,16 @@ const MonthNavBar = ({ month, year }: { month: number; year: number }) => {
   const nextIsFuture = isFuture(next.month, next.year);
 
   return (
-    <MonthNav>
-      <Link href={{ pathname: '/archive-page', query: prev }}>
+    <MonthNav aria-label="Archive navigation">
+      <Link
+        href={{ pathname: '/archive-page', query: prev }}
+        aria-label={`Previous month: ${getMonthName(prev.month)} ${prev.year}`}>
         ← {getMonthName(prev.month)} {prev.year}
       </Link>
       {!nextIsFuture && (
-        <Link href={{ pathname: '/archive-page', query: next }}>
+        <Link
+          href={{ pathname: '/archive-page', query: next }}
+          aria-label={`Next month: ${getMonthName(next.month)} ${next.year}`}>
           {getMonthName(next.month)} {next.year} →
         </Link>
       )}


### PR DESCRIPTION
## Summary

Thursday accessibility pass. Three focused ARIA fixes across two files:

- **`components/nav.tsx`** — The mobile burger button had `aria-expanded` but no `aria-controls`, so screen readers couldn't identify _which_ element it toggled. Added `id="main-nav-list"` to the `<NavList>` and `aria-controls="main-nav-list"` to `<BurgerButton>`. Also added `aria-label="Main"` to the `<StyledNav>` element so the primary navigation landmark is clearly named when screen readers list landmarks (distinguishes it from the post-navigation `<nav>` and the archive-page month navs).

- **`pages/archive-page.tsx`** — The archive page renders two identical `<MonthNavBar>` components (one above, one below the post list), each outputting an unlabelled `<nav>`. Screen readers presenting a landmark list would show two anonymous "navigation" regions with no way to tell them apart. Added `aria-label="Archive navigation"` to `<MonthNav>`. Also added explicit `aria-label` to the prev/next month `<Link>` elements (`"Previous month: January 2024"` / `"Next month: March 2024"`) so the visible arrow characters `←` and `→` are not the accessible name announced to screen reader users.

## Test plan

- [ ] Verify with a screen reader (NVDA/VoiceOver) that the landmark list now shows "Main navigation", "Archive navigation", and "Post navigation" as distinct entries
- [ ] Confirm the burger button's accessible description references the nav list (`aria-controls="main-nav-list"`)
- [ ] Confirm prev/next archive links are announced as "Previous month: …" / "Next month: …" rather than "left arrow …"
- [ ] Run existing test suite — no behavioural changes, only attribute additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y564TFKNbsABSAxUhKrqqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y564TFKNbsABSAxUhKrqqC)_