### PR TITLE
feat(blog): surface RSS feed for browser auto-discovery and subscriber link

### DIFF
--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -113,7 +113,7 @@ export default function Meta({
         <meta property="article:author" content={articleAuthor} />
       )}
       {metaKeywords && <meta name="keywords" content={metaKeywords} />}
-      <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
+      <link rel="alternate" type="application/rss+xml" title="World Of Winfield" href="/api/feed" />
       <meta
         name="description"
         content={

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -66,6 +66,7 @@ export default function Index({ allPosts, preview }: IndexPageProps) {
       </Container>
       <BrowseTopicsBar>
         <Link href="/tags">Browse all topics →</Link>
+        <RssLink href="/api/feed">Subscribe via RSS</RssLink>
       </BrowseTopicsBar>
       <SearchBar onSearch={handleSearch} />
       <SearchResults searchResults={searchResults} />
@@ -95,6 +96,18 @@ const BrowseTopicsBar = styled.div`
     &:hover {
       text-decoration: underline;
     }
+  }
+`;
+
+const RssLink = styled.a`
+  display: block;
+  font-size: 0.875rem;
+  color: #000;
+  text-decoration: none;
+  margin-top: 0.5rem;
+
+  &:hover {
+    text-decoration: underline;
   }
 `;
 


### PR DESCRIPTION
## Summary

- Fixes the `<link rel="alternate">` auto-discovery tag in `<head>` — it was pointing to `/feed.xml` (which doesn't exist) and now correctly targets `/api/feed`
- Adds title attribute to the RSS link tag for better RSS reader labelling
- Adds a visible "Subscribe via RSS" link on the blog listing page so readers can find and subscribe

## Test plan

- [ ] Open the blog page and check the page source for `<link rel="alternate" type="application/rss+xml" title="World Of Winfield" href="/api/feed" />`
- [ ] Confirm the "Subscribe via RSS" link appears below "Browse all topics" on `/blog`
- [ ] Click the RSS link and confirm `/api/feed` returns a valid RSS feed

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)