### PR TITLE
Security: minor hardening batch

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,13 +11,11 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  poweredByHeader: false,
   images: {
     loader: 'custom',
     loaderFile: './lib/imageLoader.ts',
     minimumCacheTTL: 2592000,
-  },
-  env: {
-    WORDPRESS_API_URL: process.env.WORDPRESS_API_URL,
   },
   async headers() {
     return [
@@ -43,6 +41,10 @@ const nextConfig = {
           {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
           },
         ],
       },

--- a/pages/api/blog-posts.ts
+++ b/pages/api/blog-posts.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getAllPostsForHome } from '../../lib/api';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ message: 'Method Not Allowed' });
   const after = (req.query.after as string) || null;
   const posts = await getAllPostsForHome(false, after);
   res.status(200).json(posts);

--- a/pages/api/feed.ts
+++ b/pages/api/feed.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { getAllPostsForHome } from '../../lib/api';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ message: 'Method Not Allowed' });
   const data = await getAllPostsForHome(false);
   const posts = data.edges.map(({ node }: { node: Record<string, unknown> }) => node);
 


### PR DESCRIPTION
## Summary

- `next.config.js`: Add `poweredByHeader: false` to suppress the `X-Powered-By: Next.js` header
- `next.config.js`: Add `Strict-Transport-Security` header (`max-age=63072000; includeSubDomains; preload`) to enforce HTTPS
- `next.config.js`: Remove redundant `env.WORDPRESS_API_URL` block — client-side reads already use `NEXT_PUBLIC_WORDPRESS_API_URL`
- `pages/api/blog-posts.ts` + `pages/api/feed.ts`: Restrict both routes to GET only, returning 405 for other methods

Closes #450

## Test plan

- [ ] Build succeeds (`yarn build`)
- [ ] Blog and feed pages load correctly in the browser
- [ ] Verify `X-Powered-By` header is absent in responses
- [ ] Verify `Strict-Transport-Security` header is present in responses
- [ ] POST/DELETE to `/api/blog-posts` and `/api/feed` returns 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)