### PR TITLE
fix(types): correct preview and seoProps TypeScript type issues

### DIFF
--- a/components/alert.test.tsx
+++ b/components/alert.test.tsx
@@ -10,12 +10,12 @@ describe('Alert', () => {
   });
 
   it('renders the preview message when preview is truthy', () => {
-    render(<Alert preview="true" />);
+    render(<Alert preview={true} />);
     expect(screen.getByText(/This is a page preview/)).toBeInTheDocument();
   });
 
   it('renders an exit-preview link when in preview mode', () => {
-    render(<Alert preview="true" />);
+    render(<Alert preview={true} />);
     const link = screen.getByRole('link', { name: /Click here/i });
     expect(link).toHaveAttribute('href', '/api/exit-preview');
   });
@@ -25,8 +25,8 @@ describe('Alert', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('renders without error when preview is an empty string', () => {
-    const { container } = render(<Alert preview="" />);
+  it('renders without error when preview is false', () => {
+    const { container } = render(<Alert preview={false} />);
     expect(container).toBeInTheDocument();
     expect(screen.queryByText(/This is a page preview/)).not.toBeInTheDocument();
   });

--- a/components/layout.test.tsx
+++ b/components/layout.test.tsx
@@ -5,7 +5,7 @@ import Layout from './layout';
 
 jest.mock('./alert', () => ({
   __esModule: true,
-  default: ({ preview }: { preview: string | null }) =>
+  default: ({ preview }: { preview: boolean | null }) =>
     preview ? <div data-testid="alert">Preview Mode</div> : null,
 }));
 
@@ -61,7 +61,7 @@ describe('Layout', () => {
 
   it('renders the alert banner when in preview mode', () => {
     render(
-      <Layout preview="true">
+      <Layout preview={true}>
         <p>Content</p>
       </Layout>,
     );

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -1,22 +1,9 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import type { SeoProps } from '../lib/types';
 
-type seoProps = {
-  seo?: {
-    opengraphDescription: string;
-    opengraphImage?: {
-      uri: string;
-      altText: string;
-      mediaItemUrl: string;
-      mediaDetails: {
-        width: string;
-        height: string;
-      };
-    } | null;
-    opengraphTitle: string;
-    opengraphSiteName: string;
-    metaKeywords?: string;
-  };
+type MetaProps = {
+  seo?: SeoProps;
   title?: string;
   ogType?: string;
   articleDate?: string;
@@ -31,7 +18,7 @@ export default function Meta({
   articleDate,
   articleModified,
   articleAuthor,
-}: seoProps) {
+}: MetaProps) {
   const router = useRouter();
   const currentUrl = router.asPath;
   const siteAddress = 'https://www.worldofwinfield.co.uk';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,7 +31,7 @@ type SinglePostProps = {
       };
     }[];
   };
-  seo: seoProps;
+  seo: SeoProps;
 };
 
 export type AdjacentPost = {
@@ -69,7 +69,7 @@ export type PostProps = {
       };
     }[];
   };
-  preview: string;
+  preview: boolean | null;
   relatedPosts: RelatedPost[];
 };
 
@@ -122,7 +122,7 @@ export type PostsProps = {
         };
       }[];
     };
-    seo: seoProps;
+    seo: SeoProps;
     author: AuthorProps;
     categories: {
       edges: {
@@ -191,7 +191,7 @@ export type IndexPageProps = {
         content: string;
         author: AuthorProps;
         excerpt: string;
-        seo: seoProps;
+        seo: SeoProps;
       };
     }[];
     pageInfo: {
@@ -220,11 +220,11 @@ export type IndexPageProps = {
         content: string;
         author: AuthorProps;
         excerpt: string;
-        seo: seoProps;
+        seo: SeoProps;
       };
     }[];
   };
-  preview: string;
+  preview: boolean;
   jamesImages: JamesImagesProps;
   randomPosts: {
     slug: string;
@@ -402,8 +402,8 @@ export type MoreStoriesProps = {
 
 export type LayoutProps = {
   children: React.ReactNode;
-  preview: string | null;
-  seo?: seoProps | null;
+  preview: boolean | null;
+  seo?: SeoProps | null;
   title?: string;
   ogType?: string;
   articleDate?: string;
@@ -443,10 +443,10 @@ export type ContainerProps = {
 };
 
 export type AlertProps = {
-  preview: string | null;
+  preview: boolean | null;
 };
 
-export type seoProps = {
+export type SeoProps = {
   opengraphDescription: string;
   opengraphImage?: {
     uri: string;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -44,7 +44,7 @@ export default function Custom404() {
   };
 
   return (
-    <Layout preview="" seo={seo} title="404 - Page Not Found">
+    <Layout preview={null} seo={seo} title="404 - Page Not Found">
       <Container>
         <article>
           <Grid>

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -66,7 +66,7 @@ export default function Post({ post, preview, relatedPosts, adjacentPosts }: Pos
   );
 }
 
-export const getStaticProps: GetStaticProps = async ({ params }) => {
+export const getStaticProps: GetStaticProps = async ({ params, preview = false }) => {
   const slug = params?.slug as string;
 
   if (!slug || !/^[a-zA-Z0-9-]+$/.test(slug)) {
@@ -88,6 +88,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   return {
     props: {
       post: data,
+      preview,
       relatedPosts,
       adjacentPosts,
     },


### PR DESCRIPTION
## Summary

- **Rename `seoProps` → `SeoProps`** in `lib/types.ts` to follow the PascalCase convention for TypeScript type aliases; update all 5 internal usages in the same file
- **Deduplicate `meta.tsx` type**: import `SeoProps` from `lib/types.ts` and replace the hand-rolled local `seoProps` definition with a `MetaProps` alias that references the canonical type — eliminates shape drift between the two
- **Fix `preview` type throughout**: Next.js `context.preview` is `boolean`, not `string`; change `preview` from `string` / `string | null` to `boolean` / `boolean | null` in `PostProps`, `IndexPageProps`, `LayoutProps`, and `AlertProps`
- **Pass `preview` in `[slug].tsx` `getStaticProps`**: the component destructured `preview` from props but `getStaticProps` never included it, so it was always `undefined` at runtime; now it is extracted from context (defaulting to `false`) and forwarded correctly
- **Fix `404.tsx`**: `preview=""` was semantically wrong (empty string ≠ "not in preview") and is now rejected by the tightened type; changed to `preview={null}`
- **Update tests**: `alert.test.tsx` and `layout.test.tsx` updated to pass `boolean` values instead of string literals

## Test plan

- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] Alert component tests pass (`preview={true}` shows banner, `preview={null}` / `preview={false}` do not)
- [ ] Layout component tests pass
- [ ] No runtime regressions on the 404 page, blog post pages, or the blog index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7D5W1Re2NaAJbfmKaHE7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7D5W1Re2NaAJbfmKaHE7u)_