### PR TITLE
fix(security): CSP connect-src gaps + add Playwright e2e tests

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,8 @@
       "Bash(curl -s http://localhost:3000/favourite-books)",
       "Bash(git log *)",
       "Bash(npx playwright *)",
-      "Bash(yarn test:e2e)"
+      "Bash(yarn test:e2e)",
+      "Bash(yarn lint:fix)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,11 @@
       "Bash(git pull *)",
       "Bash(git fetch *)",
       "Bash(git rebase *)",
-      "Bash(git merge *)"
+      "Bash(git merge *)",
+      "Bash(curl -s http://localhost:3000/favourite-books)",
+      "Bash(git log *)",
+      "Bash(npx playwright *)",
+      "Bash(yarn test:e2e)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ package-lock.json
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/e2e/favourites.spec.ts
+++ b/e2e/favourites.spec.ts
@@ -23,7 +23,9 @@ test.describe('Favourites', () => {
     await expect(rows.first()).toBeVisible({ timeout: 15000 });
     expect(await rows.count()).toBeGreaterThan(0);
 
-    const cspErrors = consoleErrors.filter((e) => /Content Security Policy|Refused to connect/i.test(e));
+    const cspErrors = consoleErrors.filter((e) =>
+      /Content Security Policy|Refused to connect/i.test(e),
+    );
     expect(cspErrors).toEqual([]);
   });
 });

--- a/e2e/favourites.spec.ts
+++ b/e2e/favourites.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Favourites', () => {
+  test('hub page lists favourite categories with entry counts', async ({ page }) => {
+    await page.goto('/favourites');
+    await expect(page.getByRole('link', { name: /Books/ })).toBeVisible();
+    await expect(page.getByText(/\d+ entries/).first()).toBeVisible();
+  });
+
+  test('a favourites category page loads real data rows from the Google Sheet', async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto('/favourite-books');
+
+    // Guards against the CSP connect-src regression that silently blocked
+    // the client-side fetch to sheets.googleapis.com and left the table empty.
+    const rows = page.locator('table tbody tr');
+    await expect(rows.first()).toBeVisible({ timeout: 15000 });
+    expect(await rows.count()).toBeGreaterThan(0);
+
+    const cspErrors = consoleErrors.filter((e) => /Content Security Policy|Refused to connect/i.test(e));
+    expect(cspErrors).toEqual([]);
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Home page', () => {
+  test('loads and shows the site title', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response?.status()).toBeLessThan(400);
+    await expect(page).toHaveTitle(/World Of Winfield/);
+  });
+
+  test('has no Content-Security-Policy violations on load', async ({ page }) => {
+    const cspErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' && /Content Security Policy/i.test(msg.text())) {
+        cspErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    expect(cspErrors).toEqual([]);
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test('navigates from home to the favourites hub', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Favourites', exact: false }).first().click();
+    await expect(page).toHaveURL(/\/favourites$/);
+    await expect(page.getByRole('heading', { name: 'Favourites' })).toBeVisible();
+  });
+
+  test('navigates from home to the blog', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Blog', exact: false }).first().click();
+    await expect(page).toHaveURL(/\/blog$/);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ const createJestConfig = nextJest({
 const config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/', '<rootDir>/e2e/'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     'next/image': '<rootDir>/__mocks__/nextImageMock.tsx',

--- a/next.config.js
+++ b/next.config.js
@@ -54,7 +54,7 @@ const nextConfig = {
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
               "font-src 'self'",
-              "connect-src 'self' https://www.google-analytics.com https://vercel.live",
+              "connect-src 'self' https://*.google-analytics.com https://vercel.live https://sheets.googleapis.com",
               'frame-src https:',
               "frame-ancestors 'none'",
             ].join('; '),

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "biome format --write .",
     "knip": "knip",
     "test": "jest",
+    "test:e2e": "playwright test",
     "postbuild": "next-sitemap"
   },
   "lint-staged": {
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
     "@next/bundle-analyzer": "^16.2.9",
+    "@playwright/test": "^1.61.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/react": "^16.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3100',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'yarn build && yarn start -p 3100',
+    url: 'http://localhost:3100',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,7 +293,7 @@
 
 "@biomejs/biome@^2.4.14":
   version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-2.5.1.tgz#4e642f3c80854deb1a2b9feb79f332ea6b7760ea"
+  resolved "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz"
   integrity sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==
   optionalDependencies:
     "@biomejs/cli-darwin-arm64" "2.5.1"
@@ -332,7 +332,7 @@
 
 "@biomejs/cli-linux-x64@2.5.1":
   version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz#743069c77c07a76c906a889cd4877651689206a2"
+  resolved "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz"
   integrity sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==
 
 "@biomejs/cli-win32-arm64@2.5.1":
@@ -347,12 +347,12 @@
 
 "@corex/deepmerge@^4.0.43":
   version "4.0.43"
-  resolved "https://registry.yarnpkg.com/@corex/deepmerge/-/deepmerge-4.0.43.tgz#9bd42559ebb41cc5a7fb7cfeea5f231c20977dca"
+  resolved "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz"
   integrity sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz"
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
@@ -422,7 +422,7 @@
 
 "@emnapi/wasi-threads@1.2.2":
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz#4c93becf5bfa3b13d1bbdcc06aee38321ad8139a"
+  resolved "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz"
   integrity sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==
   dependencies:
     tslib "^2.4.0"
@@ -1168,7 +1168,7 @@
 
 "@oxc-parser/binding-linux-x64-gnu@0.137.0":
   version "0.137.0"
-  resolved "https://registry.yarnpkg.com/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.137.0.tgz#058b6589186549bd999c4245cdab0e2639676cf4"
+  resolved "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.137.0.tgz"
   integrity sha512-36mGWtg7PyFzjJwGDkH6/F4o2nIDEoKXLPr/X/lwqklkomQwJJt1I5GJVmGhovUEmgPK5WAeAZMqlFCehwiy9Q==
 
 "@oxc-parser/binding-linux-x64-musl@0.137.0":
@@ -1207,7 +1207,7 @@
 
 "@oxc-project/types@^0.137.0":
   version "0.137.0"
-  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.137.0.tgz#56e77f8bb221fa05f18b1cd34d73f94f0954a773"
+  resolved "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz"
   integrity sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==
 
 "@oxc-resolver/binding-android-arm-eabi@11.21.3":
@@ -1277,7 +1277,7 @@
 
 "@oxc-resolver/binding-linux-x64-gnu@11.21.3":
   version "11.21.3"
-  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.3.tgz#add3b76293ef1e8959e00bc6b62ada766e18485c"
+  resolved "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.3.tgz"
   integrity sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==
 
 "@oxc-resolver/binding-linux-x64-musl@11.21.3":
@@ -1318,6 +1318,13 @@
   version "0.2.9"
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
+
+"@playwright/test@^1.61.1":
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.1.tgz#48568dc22af7819e55fa5e8e3bc79b7e6a3e6675"
+  integrity sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==
+  dependencies:
+    playwright "1.61.1"
 
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.29"
@@ -2219,14 +2226,14 @@ fb-watchman@^2.0.2:
 
 fd-package-json@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fd-package-json/-/fd-package-json-2.0.0.tgz#03f53ce5a0af552c2f4faf703a24e526310a2411"
+  resolved "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz"
   integrity sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==
   dependencies:
     walk-up-path "^4.0.0"
 
 fdir@^6.5.0:
   version "6.5.0"
-  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 fill-range@^7.1.1:
@@ -2259,7 +2266,7 @@ foreground-child@^3.1.0:
 
 formatly@^0.3.0:
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/formatly/-/formatly-0.3.0.tgz#5bb3b4e692f5a8c74ad8fe26154dd0a74aac6819"
+  resolved "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz"
   integrity sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==
   dependencies:
     fd-package-json "^2.0.0"
@@ -2268,6 +2275,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@^2.3.3:
   version "2.3.3"
@@ -2301,7 +2313,7 @@ get-stream@^6.0.0:
 
 get-tsconfig@4.14.0:
   version "4.14.0"
-  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.14.0.tgz#985d85c52a9903864280ccc2448d413fbf1efed8"
+  resolved "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz"
   integrity sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==
   dependencies:
     resolve-pkg-maps "^1.0.0"
@@ -2945,7 +2957,7 @@ jest@^30.0.0:
 
 jiti@^2.7.0:
   version "2.7.0"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
+  resolved "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz"
   integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
 
 js-tokens@^4.0.0:
@@ -3004,7 +3016,7 @@ json5@^2.2.3:
 
 knip@^6.0.0:
   version "6.23.0"
-  resolved "https://registry.yarnpkg.com/knip/-/knip-6.23.0.tgz#8581f5c01e24be0b21990094f6444aa15b89f11e"
+  resolved "https://registry.npmjs.org/knip/-/knip-6.23.0.tgz"
   integrity sha512-2DvAOX2pZWiG4SLvRRxOAU0aWGEn1ZoVblI541xIoXFdHqq2THMZXy66/qcY5WGuW3TXhb9T1x1zd/Hd1u+yqg==
   dependencies:
     fdir "^6.5.0"
@@ -3249,7 +3261,7 @@ opener@^1.5.2:
 
 oxc-parser@^0.137.0:
   version "0.137.0"
-  resolved "https://registry.yarnpkg.com/oxc-parser/-/oxc-parser-0.137.0.tgz#b88a1c5ae2b3d367b9d0a1c1cb42ca5c81745ec4"
+  resolved "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.137.0.tgz"
   integrity sha512-yFImD+WLElJpLKy8llG1qe4DCmMsL18peRp8XP1JKfig/gISbJkglnpDtX2aTmAn10kZF7164HbN2H8QPsXxGg==
   dependencies:
     "@oxc-project/types" "^0.137.0"
@@ -3277,7 +3289,7 @@ oxc-parser@^0.137.0:
 
 oxc-resolver@11.21.3:
   version "11.21.3"
-  resolved "https://registry.yarnpkg.com/oxc-resolver/-/oxc-resolver-11.21.3.tgz#0fde1bd801ce1c2c95ef010406073aa7cd0fe8cc"
+  resolved "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.3.tgz"
   integrity sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==
   optionalDependencies:
     "@oxc-resolver/binding-android-arm-eabi" "11.21.3"
@@ -3409,6 +3421,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
+  integrity sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==
+
+playwright@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.1.tgz#d8c0c06eb93c28981afc747bace453bdbd5018bc"
+  integrity sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==
+  dependencies:
+    playwright-core "1.61.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 postcss@8.4.31:
   version "8.4.31"
@@ -3559,7 +3585,7 @@ resolve-from@^5.0.0:
 
 resolve-pkg-maps@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  resolved "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
 resolve@^1.19.0:
@@ -3697,7 +3723,7 @@ slash@^3.0.0:
 
 smol-toml@^1.6.1:
   version "1.7.0"
-  resolved "https://registry.yarnpkg.com/smol-toml/-/smol-toml-1.7.0.tgz#ed1b259ce7e05907df1abe758971bd0a0ef2c0dd"
+  resolved "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz"
   integrity sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==
 
 source-map-js@^1.0.2:
@@ -3822,7 +3848,7 @@ strip-indent@^3.0.0:
 
 strip-json-comments@5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-5.0.3.tgz#b7304249dd402ee67fd518ada993ab3593458bcf"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz"
   integrity sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==
 
 strip-json-comments@^3.1.1:
@@ -3902,7 +3928,7 @@ through@^2.3.8:
 
 tinyglobby@^0.2.17:
   version "0.2.17"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz"
   integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
   dependencies:
     fdir "^6.5.0"
@@ -3997,7 +4023,7 @@ typescript@6.0.3:
 
 unbash@^4.0.1:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/unbash/-/unbash-4.0.2.tgz#79ec0fcca990e24c78e6bddcc9b8cb7d756533f0"
+  resolved "https://registry.npmjs.org/unbash/-/unbash-4.0.2.tgz"
   integrity sha512-8gwNZ29+0/3zmXw7ToIHZtg6wK37xnniRUdBt7B27xZxaxfgR5tGMaGHT0t0dLtBV9fXE7zurh0s6Z1DHVjfWg==
 
 undici-types@~7.18.0:
@@ -4068,7 +4094,7 @@ w3c-xmlserializer@^5.0.0:
 
 walk-up-path@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-4.0.0.tgz#590666dcf8146e2d72318164f1f2ac6ef51d4198"
+  resolved "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz"
   integrity sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==
 
 walker@^1.0.8:
@@ -4213,7 +4239,7 @@ yaml@^1.10.0:
 
 yaml@^2.9.0:
   version "2.9.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz"
   integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@^21.1.1:
@@ -4246,5 +4272,5 @@ yocto-queue@^0.1.0:
 
 zod@^4.1.11:
   version "4.4.3"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  resolved "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary
- Fixes a pre-existing bug: the CSP `connect-src` directive didn't whitelist `sheets.googleapis.com`, so every `/favourite-*` page's client-side fetch was silently blocked by the browser, leaving tables empty (only a `console.error`, no user-visible failure).
- Also broadens `connect-src` to `https://*.google-analytics.com` — GA's region-specific collect endpoints (e.g. `region1.google-analytics.com`) were being blocked too, found while writing the e2e CSP test.
- Adds Playwright as the e2e test runner (none existed before), with 3 spec files covering home page load, navigation, and a favourites data-loading test that specifically guards against this CSP regression.

## Test plan
- [x] `yarn test:e2e` — 6/6 passing against a fresh production build
- [x] Verified `/favourite-books` table now renders real rows instead of staying empty
- [x] Confirmed no CSP console errors on home page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)