### PR TITLE
quality: replace inline style prop in ArchiveDropdown

### DIFF
--- a/components/archive.tsx
+++ b/components/archive.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { StyledSelect } from './core-components';
@@ -36,8 +37,7 @@ const ArchiveDropdown = () => {
   return (
     <div>
       <p>Posts from the archives</p>
-      <div
-        style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'center' }}>
+      <ArchiveSelectRow>
         <label htmlFor="archive-month-select">Select month</label>
         <StyledSelect id="archive-month-select" onChange={handleSelectMonth}>
           <option value="">Select Month</option>
@@ -47,9 +47,16 @@ const ArchiveDropdown = () => {
             </option>
           ))}
         </StyledSelect>
-      </div>
+      </ArchiveSelectRow>
     </div>
   );
 };
+
+const ArchiveSelectRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: center;
+`;
 
 export default ArchiveDropdown;


### PR DESCRIPTION
## Quality improvement

**Category:** Bad patterns
**Issue:** `components/archive.tsx` used a raw `style={{ ... }}` prop on the wrapper `div` around the month selector, rather than an Emotion styled component like the rest of the codebase.
**Fix:** Extracted the inline style object into a new `ArchiveSelectRow` styled component (`components/archive.tsx`), keeping the same layout (flex row, centered, `0.5rem` gap).
**Next suggestion:** `components/homepage-block.tsx` (lines 76 and 143) sets inline `style={{ backgroundColor: randomColour }}` — this one is dynamic so it can't be lifted to a static styled component directly, but it could use Emotion's `css` prop with the dynamic value instead, worth a look next time this category comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012e9uCYCnLyXCZrAVm68yK1)_