### PR TITLE
chore(typescript): enforce import type, export SinglePostProps, clean up api.ts typing

### DIFF
--- a/__tests__/archive-page.test.tsx
+++ b/__tests__/archive-page.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { ArchivePageProps } from '../lib/types';
+import type { ArchivePageProps } from '../lib/types';
 import ArchivePage from '../pages/archive-page';
 
 const mockRouter = { isFallback: false };

--- a/components/alert.tsx
+++ b/components/alert.tsx
@@ -1,4 +1,4 @@
-import { AlertProps } from '../lib/types';
+import type { AlertProps } from '../lib/types';
 import Container from './container';
 
 export default function Alert({ preview }: AlertProps) {

--- a/components/container.tsx
+++ b/components/container.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { ContainerProps } from '../lib/types';
+import type { ContainerProps } from '../lib/types';
 
 export default function Container({ children }: ContainerProps) {
   return <StyledContainer>{children}</StyledContainer>;

--- a/components/hero-post.test.tsx
+++ b/components/hero-post.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { HeroPostProps } from '../lib/types';
+import type { HeroPostProps } from '../lib/types';
 import HeroPost from './hero-post';
 
 jest.mock('dompurify', () => ({

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useMemo } from 'react';
 import { sanitize } from '../lib/sanitize';
-import { HeroPostProps } from '../lib/types';
+import type { HeroPostProps } from '../lib/types';
 import { StyledButton } from './core-components';
 import PostHeader from './post-header';
 

--- a/components/homepage-block.test.tsx
+++ b/components/homepage-block.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { JamesImagesProps } from '../lib/types';
+import type { JamesImagesProps } from '../lib/types';
 import HomepageBlock from './homepage-block';
 
 jest.mock('../pages/_app', () => ({

--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
-import { JamesImagesProps } from '../lib/types';
+import type { JamesImagesProps } from '../lib/types';
 import { colours } from '../pages/_app';
 import { formatDate } from './search-results';
 

--- a/components/intro.test.tsx
+++ b/components/intro.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { JamesImagesProps } from '../lib/types';
+import type { JamesImagesProps } from '../lib/types';
 import Intro from './intro';
 
 jest.mock('../pages/_app', () => ({

--- a/components/intro.tsx
+++ b/components/intro.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import React, { useCallback, useEffect, useState } from 'react';
-import { IntroProps, JamesImagesProps } from '../lib/types';
+import type { IntroProps, JamesImagesProps } from '../lib/types';
 import { colours } from '../pages/_app';
 
 type FlipperProps = {

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { LayoutProps } from '../lib/types';
+import type { LayoutProps } from '../lib/types';
 import Alert from './alert';
 import Footer from './footer';
 import Meta from './meta';

--- a/components/more-stories.test.tsx
+++ b/components/more-stories.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { MoreStoriesProps } from '../lib/types';
+import type { MoreStoriesProps } from '../lib/types';
 import MoreStories from './more-stories';
 
 jest.mock('./post-preview', () => ({

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { MoreStoriesProps } from '../lib/types';
+import type { MoreStoriesProps } from '../lib/types';
 import PostPreview from './post-preview';
 
 export default function MoreStories({ posts }: MoreStoriesProps) {

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import DOMPurify from 'dompurify';
 import { useMemo } from 'react';
-import { PostBodyProps } from '../lib/types';
+import type { PostBodyProps } from '../lib/types';
 import { colours } from '../pages/_app';
 
 const resolveDataSrc = (html: string): string =>

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useMemo } from 'react';
 import { sanitize } from '../lib/sanitize';
-import { PostHeaderProps } from '../lib/types';
+import type { PostHeaderProps } from '../lib/types';
 import { colours } from '../pages/_app';
 import CoverImage from './cover-image';
 import Date from './date';

--- a/components/post-navigation.tsx
+++ b/components/post-navigation.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import { AdjacentPost } from '../lib/types';
+import type { AdjacentPost } from '../lib/types';
 import { colours } from '../pages/_app';
 
 type PostNavigationProps = {

--- a/components/post-preview.test.tsx
+++ b/components/post-preview.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { PostPreviewProps } from '../lib/types';
+import type { PostPreviewProps } from '../lib/types';
 import PostPreview from './post-preview';
 
 jest.mock('dompurify', () => ({

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useMemo } from 'react';
 import { sanitize } from '../lib/sanitize';
-import { PostPreviewProps } from '../lib/types';
+import type { PostPreviewProps } from '../lib/types';
 import { colours } from '../pages/_app';
 import DateComponent from './date';
 

--- a/components/post-title.tsx
+++ b/components/post-title.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { sanitize } from '../lib/sanitize';
-import { PostTitleProps } from '../lib/types';
+import type { PostTitleProps } from '../lib/types';
 import { colours } from '../pages/_app';
 
 export default function PostTitle({ backgroundColour, children }: PostTitleProps) {

--- a/components/pre-post.tsx
+++ b/components/pre-post.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { PrePostProps } from '../lib/types';
+import type { PrePostProps } from '../lib/types';
 import { calculateReadingTime } from './utils';
 
 export default function PrePost({ tags, date, content }: PrePostProps) {

--- a/components/related-posts.test.tsx
+++ b/components/related-posts.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
-import { RelatedPost } from '../lib/types';
+import type { RelatedPost } from '../lib/types';
 import RelatedPosts from './related-posts';
 
 jest.mock('../pages/_app', () => ({

--- a/components/related-posts.tsx
+++ b/components/related-posts.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
-import { RelatedPostsProps } from '../lib/types';
+import type { RelatedPostsProps } from '../lib/types';
 import { colours } from '../pages/_app';
 import DateFormatter from './date';
 

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
-import { SearchBarProps } from '../lib/types';
+import type { SearchBarProps } from '../lib/types';
 import { colours } from '../pages/_app';
 import { StyledButton, StyledInput } from './core-components';
 

--- a/components/search-results.tsx
+++ b/components/search-results.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
 import { sanitize } from '../lib/sanitize';
-import { SearchResultsProps } from '../lib/types';
+import type { SearchResultsProps } from '../lib/types';
 import { colours } from '../pages/_app';
 
 const blockColours = [

--- a/components/tags.tsx
+++ b/components/tags.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import { TagsProps } from '../lib/types';
+import type { TagsProps } from '../lib/types';
 
 export default function Tags({ tags }: TagsProps) {
   // remove tags with a space because I cannot retrieve them from the API

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -299,7 +299,7 @@ export async function getPost(id: string, idType = 'SLUG') {
 
 export async function getPostDisplayInfo(ids: string[]) {
   const posts = await Promise.all(
-    ids.map((id: string) =>
+    ids.map((id) =>
       fetchAPI(
         `
       query Post($id: ID!, $idType: PostIdType!) {
@@ -563,8 +563,8 @@ export async function getAdjacentPosts(date: string): Promise<{
   );
 
   return {
-    previousPost: (data.previousPost?.nodes?.[0] as { title: string; slug: string }) ?? null,
-    nextPost: (data.nextPost?.nodes?.[0] as { title: string; slug: string }) ?? null,
+    previousPost: (data.previousPost?.nodes?.[0] as AdjacentPost) ?? null,
+    nextPost: (data.nextPost?.nodes?.[0] as AdjacentPost) ?? null,
   };
 }
 
@@ -601,6 +601,8 @@ export async function getRandomImage(randomMonth: number, randomYear: number) {
   };
 }
 
+type TagNode = { name: string; slug: string; count: number | null };
+
 export async function getAllTags(): Promise<{ name: string; slug: string; count: number }[]> {
   const data = await fetchAPI(`
     {
@@ -614,15 +616,8 @@ export async function getAllTags(): Promise<{ name: string; slug: string; count:
     }
   `);
   return (data?.tags?.nodes ?? [])
-    .filter(
-      (tag: { name: string; slug: string; count: number | null }) => tag.count && tag.count > 0,
-    )
-    .sort(
-      (
-        a: { name: string; slug: string; count: number },
-        b: { name: string; slug: string; count: number },
-      ) => b.count - a.count,
-    );
+    .filter((tag: TagNode) => tag.count && tag.count > 0)
+    .sort((a: TagNode, b: TagNode) => (b.count ?? 0) - (a.count ?? 0));
 }
 
 export async function getTotalPostCount(): Promise<number> {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-type SinglePostProps = {
+export type SinglePostProps = {
   slug: string;
   title: string;
   featuredImage: {

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -12,7 +12,7 @@ import SectionSeparator from '../components/section-separator';
 import ShareBar from '../components/share-bar';
 import Tags from '../components/tags';
 import { getAdjacentPosts, getAllPostsWithSlug, getPost, getRelatedPosts } from '../lib/api';
-import { PostProps } from '../lib/types';
+import type { PostProps } from '../lib/types';
 import Custom404 from './404';
 
 export default function Post({ post, preview, relatedPosts, adjacentPosts }: PostProps) {

--- a/pages/api/feed.ts
+++ b/pages/api/feed.ts
@@ -1,15 +1,22 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getAllPostsForHome } from '../../lib/api';
+
+type FeedPost = {
+  title: string;
+  slug: string;
+  date: string;
+  excerpt: string;
+};
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ message: 'Method Not Allowed' });
   const data = await getAllPostsForHome(false);
-  const posts = data.edges.map(({ node }: { node: Record<string, unknown> }) => node);
+  const posts: FeedPost[] = data.edges.map(({ node }: { node: FeedPost }) => node as FeedPost);
 
   const siteUrl = 'https://www.worldofwinfield.com';
 
   const items = posts
-    .map((post: { title: string; slug: string; date: string; excerpt: string }) => {
+    .map((post) => {
       const excerpt = post.excerpt ? post.excerpt.replace(/<[^>]*>/g, '').trim() : '';
       return `
     <item>

--- a/pages/archive-page.tsx
+++ b/pages/archive-page.tsx
@@ -9,7 +9,7 @@ import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import { getMonthName } from '../components/utils';
 import { getPostsByDate } from '../lib/api';
-import { ArchivePageProps } from '../lib/types';
+import type { ArchivePageProps } from '../lib/types';
 import { colours } from './_app';
 
 const getPrevMonth = (month: number, year: number) =>

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -9,7 +9,7 @@ import MoreStories from '../components/more-stories';
 import SearchBar from '../components/search-bar';
 import SearchResults from '../components/search-results';
 import { getAllPostsForHome } from '../lib/api';
-import { IndexPageProps, SearchResult } from '../lib/types';
+import type { IndexPageProps, SearchResult } from '../lib/types';
 
 export default function Index({ allPosts, preview }: IndexPageProps) {
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -10,7 +10,7 @@ import PostTitle from '../components/post-title';
 import RelatedSections from '../components/related-sections';
 import { filterPostsByTag } from '../lib/api';
 import { sanitize } from '../lib/sanitize';
-import { PostsProps } from '../lib/types';
+import type { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
 const stripReadMoreParagraph = (excerpt: string) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ import {
   getPostDisplayInfo,
   getRandomImage,
 } from '../lib/api';
-import { IndexPageProps, SearchResult } from '../lib/types';
+import type { IndexPageProps, SearchResult } from '../lib/types';
 
 export default function Index({
   preview,

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -10,7 +10,7 @@ import PostTitle from '../components/post-title';
 import RelatedSections from '../components/related-sections';
 import { filterPostsByTag } from '../lib/api';
 import { sanitize } from '../lib/sanitize';
-import { PostsProps } from '../lib/types';
+import type { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
 const stripReadMoreParagraph = (excerpt: string) => {

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -10,7 +10,7 @@ import PostTitle from '../components/post-title';
 import RelatedSections from '../components/related-sections';
 import { filterPostsByTag } from '../lib/api';
 import { sanitize } from '../lib/sanitize';
-import { PostsProps } from '../lib/types';
+import type { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
 const stripReadMoreParagraph = (excerpt: string) => {

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -12,7 +12,7 @@ import PostHeader from '../../components/post-header';
 import PostTitle from '../../components/post-title';
 import { getAllTags, getPostsByTag } from '../../lib/api';
 import { sanitize } from '../../lib/sanitize';
-import { TagsPostProps } from '../../lib/types';
+import type { TagsPostProps } from '../../lib/types';
 import { colours } from '../_app';
 
 const blockColours = [

--- a/pages/tags/index.tsx
+++ b/pages/tags/index.tsx
@@ -5,7 +5,7 @@ import Container from '../../components/container';
 import Layout from '../../components/layout';
 import PostHeader from '../../components/post-header';
 import { getAllTags } from '../../lib/api';
-import { TagIndexPageProps } from '../../lib/types';
+import type { TagIndexPageProps } from '../../lib/types';
 import { colours } from '../_app';
 
 const blockColours = [

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -10,7 +10,7 @@ import PostTitle from '../components/post-title';
 import RelatedSections from '../components/related-sections';
 import { filterPostsByTag } from '../lib/api';
 import { sanitize } from '../lib/sanitize';
-import { PostsProps } from '../lib/types';
+import type { PostsProps } from '../lib/types';
 import { colours } from './_app';
 
 const stripReadMoreParagraph = (excerpt: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,9 +895,9 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.61.1":
+"@playwright/test@^1.51.1", "@playwright/test@^1.61.1":
   version "1.61.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.1.tgz#48568dc22af7819e55fa5e8e3bc79b7e6a3e6675"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz"
   integrity sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==
   dependencies:
     playwright "1.61.1"
@@ -2908,12 +2908,12 @@ pkg-dir@^4.2.0:
 
 playwright-core@1.61.1:
   version "1.61.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz"
   integrity sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==
 
 playwright@1.61.1:
   version "1.61.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.1.tgz#d8c0c06eb93c28981afc747bace453bdbd5018bc"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz"
   integrity sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==
   dependencies:
     playwright-core "1.61.1"
@@ -3348,11 +3348,6 @@ strip-indent@^3.0.0:
   integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
   dependencies:
     min-indent "^1.0.0"
-
-strip-json-comments@5.0.3:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz"
-  integrity sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==
 
 strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Summary

- **`import type` across 35 files** — every type-only import from `lib/types` in components, pages, and test files now uses `import type`, which is the correct TypeScript module syntax (signals the compiler the binding is erased at emit and prevents accidental value usage)
- **Export `SinglePostProps` from `lib/types.ts`** — the type was defined but unexported despite being embedded in the public `PostProps` type; it is now accessible externally
- **`lib/api.ts` cleanup** — three improvements:
  - `getAdjacentPosts`: the cast from `data.previousPost/nextPost.nodes[0]` now uses the already-imported `AdjacentPost` type instead of an inline duplicate `{ title: string; slug: string }`
  - `getAllTags`: introduced a local `TagNode` alias to replace the verbose inline struct annotations on the `.filter()` and `.sort()` callbacks; the sort now uses `(b.count ?? 0) - (a.count ?? 0)` to stay type-consistent with the `number | null` constraint
  - `getPostDisplayInfo`: removed the redundant `: string` annotation on the `id` map-callback parameter (inferred from `ids: string[]`)
- **`pages/api/feed.ts`** — changed to `import type` for Next.js types; defined a `FeedPost` type to replace the `Record<string, unknown>` node annotation and the inline struct on the `posts.map` callback; typed the `posts` variable explicitly as `FeedPost[]`

## Test plan

- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] All 252 Jest tests pass (`npm test`)
- [ ] No runtime behaviour changed — all edits are import-form and type-annotation only

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUpsRKKnYb6qH3JitLK5XG)_