### PR TITLE
fix: resolve high-severity yarn audit vulnerabilities

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   poweredByHeader: false,
+  transpilePackages: ['d3-color', 'd3-interpolate', 'd3-zoom'],
   images: {
     loader: 'custom',
     loaderFile: './lib/imageLoader.ts',

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "ts-node": "^10.9.2"
   },
   "resolutions": {
-    "picomatch": "^4.0.0"
+    "picomatch": "^4.0.0",
+    "ws": "^8.21.0",
+    "d3-color": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,10 +2090,10 @@ d3-array@^2.5.0:
   dependencies:
     internmap "^1.0.0"
 
-"d3-color@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
-  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
+"d3-color@1 - 2", d3-color@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 "d3-dispatch@1 - 2":
   version "2.0.0"
@@ -4381,15 +4381,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@^7.3.1:
-  version "7.5.11"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz"
-  integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
-
-ws@^8.18.0:
-  version "8.20.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz"
-  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
+ws@^7.3.1, ws@^8.18.0, ws@^8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xml-name-validator@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- Force `ws` to `8.21.0` to fix GHSA-96hv-2xvq-fx4p (memory-exhaustion DoS), pulled in transitively via `jest-environment-jsdom` → `jsdom`
- Force `d3-color` to `3.1.0` to fix GHSA-36jr-mh4h-2g58 (ReDoS), pulled in transitively via `react-simple-maps` → `d3-zoom`
- `d3-color@3.1.0` ships ESM-only, so `d3-color`, `d3-interpolate`, and `d3-zoom` are added to `transpilePackages` in `next.config.js` to keep both Jest and the Next.js build working

## Test plan
- [x] `yarn audit --level high` reports 0 high/critical advisories (previously 2 high)
- [x] `yarn test` — all 42 suites / 258 tests pass
- [x] `yarn build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)