### PR TITLE
chore(typescript): tighten type imports, fix unsafe casts, correct return types

### DIFF
--- a/components/GenreDropdown.tsx
+++ b/components/GenreDropdown.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import React from 'react';
 
 type GenreDropdownProps = {
   genres: string[];
@@ -10,14 +9,14 @@ type GenreDropdownProps = {
   selectId?: string;
 };
 
-const GenreDropdown: React.FC<GenreDropdownProps> = ({
+function GenreDropdown({
   genres,
   selectedGenre,
   onChange,
   filterLabel = 'Filter by genre:',
   allOptionText = 'All Genres',
   selectId = 'genre-select',
-}) => {
+}: GenreDropdownProps) {
   return (
     <Wrapper>
       <Label htmlFor={selectId}>{filterLabel}</Label>
@@ -31,7 +30,7 @@ const GenreDropdown: React.FC<GenreDropdownProps> = ({
       </StyledSelect>
     </Wrapper>
   );
-};
+}
 
 const Wrapper = styled.div`
   margin-bottom: 1rem;

--- a/components/SortDropdown.tsx
+++ b/components/SortDropdown.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import React from 'react';
 
 type SortDropdownProps = {
   options: string[];
@@ -7,7 +6,7 @@ type SortDropdownProps = {
   onChange: (value: string) => void;
 };
 
-const SortDropdown: React.FC<SortDropdownProps> = ({ options, selected, onChange }) => {
+function SortDropdown({ options, selected, onChange }: SortDropdownProps) {
   return (
     <Wrapper>
       <Label htmlFor="sort-select">Sort by:</Label>
@@ -21,7 +20,7 @@ const SortDropdown: React.FC<SortDropdownProps> = ({ options, selected, onChange
       </Select>
     </Wrapper>
   );
-};
+}
 
 const Wrapper = styled.div`
   margin: 1rem 0;

--- a/components/utils.test.ts
+++ b/components/utils.test.ts
@@ -52,7 +52,9 @@ describe('getMonthName', () => {
 
   it('getMonthNumber and getMonthName are inverse operations', () => {
     for (let i = 1; i <= 12; i++) {
-      expect(getMonthNumber(getMonthName(i))).toBe(i);
+      const name = getMonthName(i);
+      expect(name).toBeDefined();
+      expect(getMonthNumber(name!)).toBe(i);
     }
   });
 });

--- a/components/utils.tsx
+++ b/components/utils.tsx
@@ -26,7 +26,7 @@ export const calculateReadingTime = (htmlContent: string): number => {
   return Math.max(1, Math.ceil(wordCount / 200));
 };
 
-export const getMonthName = (monthNumber: number): string => {
+export const getMonthName = (monthNumber: number): string | undefined => {
   const monthNames = [
     'January',
     'February',

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,4 +1,4 @@
-import { GetStaticPaths, GetStaticProps } from 'next';
+import type { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import Layout from '../components/layout';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,7 @@
 import createCache, { EmotionCache } from '@emotion/cache';
 import { CacheProvider, css, Global } from '@emotion/react';
 import { GoogleAnalytics } from '@next/third-parties/google';
-import { AppProps } from 'next/app';
+import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import Nav from '../components/nav';
 

--- a/pages/api/blog-posts.ts
+++ b/pages/api/blog-posts.ts
@@ -3,7 +3,8 @@ import { getAllPostsForHome } from '../../lib/api';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ message: 'Method Not Allowed' });
-  const after = (req.query.after as string) || null;
+  const rawAfter = req.query.after;
+  const after = (Array.isArray(rawAfter) ? rawAfter[0] : rawAfter) ?? null;
   const posts = await getAllPostsForHome(false, after);
   res.status(200).json(posts);
 }

--- a/pages/api/exit-preview.ts
+++ b/pages/api/exit-preview.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function exit(_: NextApiRequest, res: NextApiResponse) {
   // Exit Draft Mode by removing the cookie

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -15,7 +15,12 @@ export default async function preview(req: NextApiRequest, res: NextApiResponse)
   }
 
   // Fetch WordPress to check if the provided `id` or `slug` exists
-  const post = await getPreviewPost((id || slug) as string, id ? 'DATABASE_ID' : 'SLUG');
+  const rawParam = id || slug;
+  const postParam = Array.isArray(rawParam) ? rawParam[0] : rawParam;
+  if (!postParam) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+  const post = await getPreviewPost(postParam, id ? 'DATABASE_ID' : 'SLUG');
 
   // If the post doesn't exist prevent preview mode from being enabled
   if (!post) {

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -3,7 +3,8 @@ import { searchBlogPosts } from '../../lib/api';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ message: 'Method Not Allowed' });
-  const searchTerm = (req.query.q as string) || '';
+  const rawQ = req.query.q;
+  const searchTerm = (Array.isArray(rawQ) ? rawQ[0] : rawQ) ?? '';
   const posts = await searchBlogPosts(searchTerm);
   res.status(200).json(posts);
 }

--- a/pages/archive-page.tsx
+++ b/pages/archive-page.tsx
@@ -97,8 +97,11 @@ const ArchivePage = ({ posts: { posts }, month, year }: ArchivePageProps) => {
 };
 
 export async function getServerSideProps({ query }: GetServerSidePropsContext) {
-  const month = parseInt(Array.isArray(query.month) ? query.month[0] ?? '' : (query.month ?? ''), 10);
-  const year = parseInt(Array.isArray(query.year) ? query.year[0] ?? '' : (query.year ?? ''), 10);
+  const month = parseInt(
+    Array.isArray(query.month) ? (query.month[0] ?? '') : (query.month ?? ''),
+    10,
+  );
+  const year = parseInt(Array.isArray(query.year) ? (query.year[0] ?? '') : (query.year ?? ''), 10);
 
   if (isNaN(month) || month < 1 || month > 12) {
     return { notFound: true };

--- a/pages/archive-page.tsx
+++ b/pages/archive-page.tsx
@@ -97,8 +97,8 @@ const ArchivePage = ({ posts: { posts }, month, year }: ArchivePageProps) => {
 };
 
 export async function getServerSideProps({ query }: GetServerSidePropsContext) {
-  const month = parseInt(query.month as string, 10);
-  const year = parseInt(query.year as string, 10);
+  const month = parseInt(Array.isArray(query.month) ? query.month[0] ?? '' : (query.month ?? ''), 10);
+  const year = parseInt(Array.isArray(query.year) ? query.year[0] ?? '' : (query.year ?? ''), 10);
 
   if (isNaN(month) || month < 1 || month > 12) {
     return { notFound: true };

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import Link from 'next/link';
 import { useState } from 'react';
 import Container from '../components/container';

--- a/pages/favourites.tsx
+++ b/pages/favourites.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 import Container from '../components/container';

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { useRouter } from 'next/router';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import { useEffect, useState } from 'react';
 import HomepageBlock from '../components/homepage-block';
 import Intro from '../components/intro';

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { useRouter } from 'next/router';

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { useRouter } from 'next/router';

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticPaths, GetStaticProps } from 'next';
+import type { GetStaticPaths, GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { useRouter } from 'next/router';

--- a/pages/tags/index.tsx
+++ b/pages/tags/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import Link from 'next/link';
 import Container from '../../components/container';
 import Layout from '../../components/layout';

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { GetStaticProps } from 'next';
+import type { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
## Summary

TypeScript quality improvements across the codebase, focused on correctness rather than adding new features. Four categories of fixes:

### 1. `import type` for type-only Next.js imports (12 files)

`GetStaticProps`, `GetStaticPaths`, `AppProps`, `NextApiRequest`, and `NextApiResponse` are type-only values. With `isolatedModules: true` and `module: "nodenext"` in tsconfig, these should use `import type` to make the type-only nature explicit and allow the compiler/bundler to elide them safely.

Files updated: `_app.tsx`, `exit-preview.ts`, `index.tsx`, `blog.tsx`, `[slug].tsx`, `politics.tsx`, `travel.tsx`, `goals.tsx`, `music.tsx`, `favourites.tsx`, `tags/index.tsx`, `tags/[tag].tsx`.

### 2. Correct `getMonthName` return type (`components/utils.tsx`)

The function declared `string` as its return type, but `monthNames[monthNumber - 1]` returns `string | undefined` for out-of-range inputs (e.g. `0` or `13`). The return type is now `string | undefined`, which is what the existing tests already document (`expect(getMonthName(13)).toBeUndefined()`). The inverse-operations test in `utils.test.ts` is updated to use a non-null assertion after `toBeDefined()` to satisfy the narrowed type.

### 3. Replace `React.FC<Props>` with plain typed functions (`GenreDropdown`, `SortDropdown`)

`React.FC` adds no benefit over a plain typed function in React 18+ (the implicit `children` issue is long gone), and every other component in the codebase already uses plain functions. Switched both components to `function` declarations and removed the now-unused `import React from 'react'` (the project uses the new JSX transform via `"jsx": "react-jsx"`).

### 4. Replace unsafe `as string` casts on query params (4 files)

`req.query.*` and `context.params.*` values have type `string | string[] | undefined`. The previous `as string` casts silently coerced arrays to strings, which would produce `"someId,anotherId"` at runtime if a query param was repeated. Replaced with explicit `Array.isArray` guards that extract the first element:

- `pages/api/blog-posts.ts` — `req.query.after`
- `pages/api/search.ts` — `req.query.q`
- `pages/api/preview.ts` — `id || slug` (also adds a proper `!postParam` early return so TypeScript narrows the type without a cast)
- `pages/archive-page.tsx` — `query.month` and `query.year`

## Tests

All 78 tests across the 8 affected test suites pass after these changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012THbrFtHtAqZTF6GtAuJQc)_