### PR TITLE
test: add unit tests for processData, stripReadMoreParagraph, feed and preview APIs

### DIFF
--- a/__tests__/countries-visited.test.ts
+++ b/__tests__/countries-visited.test.ts
@@ -1,0 +1,33 @@
+import { processData } from '../pages/countries-visited';
+
+// Builds minimal raw data: a header row followed by the given data rows.
+// Each row has 14 columns (7 continents × 2 columns each: country + visited).
+const makeRawData = (rows: string[][]): string[][] => [
+  Array(14).fill('header'),
+  ...rows,
+];
+
+describe('processData', () => {
+  it("maps 'Yes' to '✔' and any other value to an empty string", () => {
+    const rawData = makeRawData([
+      ['France', 'Yes', 'USA', 'No', '', '', '', '', '', '', '', '', '', ''],
+    ]);
+    const result = processData(rawData);
+    expect(result['Europe'][0]).toEqual({ country: 'France', visited: '✔' });
+    expect(result['North America'][0]).toEqual({ country: 'USA', visited: '' });
+  });
+
+  it('skips rows where the country column is empty', () => {
+    const rawData = makeRawData([
+      // Europe row 1: country present; North America row 1: country absent
+      ['France', 'Yes', '', 'Yes', '', '', '', '', '', '', '', '', '', ''],
+      // Europe row 2: country absent; North America row 2: country present
+      ['', 'Yes', 'Canada', 'Yes', '', '', '', '', '', '', '', '', '', ''],
+    ]);
+    const result = processData(rawData);
+    expect(result['Europe']).toHaveLength(1);
+    expect(result['Europe'][0].country).toBe('France');
+    expect(result['North America']).toHaveLength(1);
+    expect(result['North America'][0].country).toBe('Canada');
+  });
+});

--- a/__tests__/countries-visited.test.ts
+++ b/__tests__/countries-visited.test.ts
@@ -2,10 +2,7 @@ import { processData } from '../pages/countries-visited';
 
 // Builds minimal raw data: a header row followed by the given data rows.
 // Each row has 14 columns (7 continents × 2 columns each: country + visited).
-const makeRawData = (rows: string[][]): string[][] => [
-  Array(14).fill('header'),
-  ...rows,
-];
+const makeRawData = (rows: string[][]): string[][] => [Array(14).fill('header'), ...rows];
 
 describe('processData', () => {
   it("maps 'Yes' to '✔' and any other value to an empty string", () => {

--- a/__tests__/tags-tag.test.ts
+++ b/__tests__/tags-tag.test.ts
@@ -1,0 +1,13 @@
+import { stripReadMoreParagraph } from '../pages/tags/[tag]';
+
+describe('stripReadMoreParagraph', () => {
+  it('removes anchor tags from excerpt HTML', () => {
+    const input = '<p>Some text.</p> <a href="/read-more" class="btn">Read More</a>';
+    expect(stripReadMoreParagraph(input)).toBe('<p>Some text.</p>');
+  });
+
+  it('returns the string unchanged when there are no anchor tags', () => {
+    const input = '<p>Just some content here.</p>';
+    expect(stripReadMoreParagraph(input)).toBe('<p>Just some content here.</p>');
+  });
+});

--- a/pages/api/feed.test.ts
+++ b/pages/api/feed.test.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAllPostsForHome } from '../../lib/api';
+import handler from './feed';
+
+jest.mock('../../lib/api');
+
+function createMockReq(overrides: Partial<NextApiRequest> = {}): NextApiRequest {
+  return { method: 'GET', ...overrides } as NextApiRequest;
+}
+
+function createMockRes() {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn(),
+    send: jest.fn(),
+  };
+  return res as unknown as NextApiResponse;
+}
+
+describe('GET /api/feed', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns 405 for non-GET requests', async () => {
+    const req = createMockReq({ method: 'POST' });
+    const res = createMockRes();
+    await handler(req, res);
+    expect(res.status as jest.Mock).toHaveBeenCalledWith(405);
+    expect(res.json as jest.Mock).toHaveBeenCalledWith({ message: 'Method Not Allowed' });
+  });
+
+  it('strips HTML tags from post excerpts in the RSS output', async () => {
+    (getAllPostsForHome as jest.Mock).mockResolvedValue({
+      edges: [
+        {
+          node: {
+            title: 'Test Post',
+            slug: 'test-post',
+            date: '2024-01-15',
+            excerpt: '<p>Some <strong>HTML</strong> content</p>',
+          },
+        },
+      ],
+    });
+    const req = createMockReq();
+    const res = createMockRes();
+    await handler(req, res);
+    const sentContent = (res.send as jest.Mock).mock.calls[0][0] as string;
+    expect(sentContent).toContain('Some HTML content');
+    expect(sentContent).not.toContain('<strong>');
+    expect(sentContent).toContain('<title><![CDATA[Test Post]]></title>');
+  });
+});

--- a/pages/api/preview.test.ts
+++ b/pages/api/preview.test.ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getPreviewPost } from '../../lib/api';
+import handler from './preview';
+
+jest.mock('../../lib/api');
+
+function createMockReq(query: Record<string, string> = {}): NextApiRequest {
+  return { query } as NextApiRequest;
+}
+
+function createMockRes(): NextApiResponse {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setPreviewData: jest.fn(),
+    writeHead: jest.fn(),
+    end: jest.fn(),
+  } as unknown as NextApiResponse;
+}
+
+describe('preview API', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when WORDPRESS_PREVIEW_SECRET env var is not set', async () => {
+    delete process.env.WORDPRESS_PREVIEW_SECRET;
+    const req = createMockReq({ secret: 'anything', id: '1' });
+    const res = createMockRes();
+    await handler(req, res);
+    expect(res.status as jest.Mock).toHaveBeenCalledWith(401);
+    expect(res.json as jest.Mock).toHaveBeenCalledWith({ message: 'Invalid token' });
+  });
+
+  it('returns 401 when secret param does not match the env var', async () => {
+    process.env.WORDPRESS_PREVIEW_SECRET = 'correct-secret';
+    const req = createMockReq({ secret: 'wrong-secret', id: '1' });
+    const res = createMockRes();
+    await handler(req, res);
+    expect(res.status as jest.Mock).toHaveBeenCalledWith(401);
+    expect(res.json as jest.Mock).toHaveBeenCalledWith({ message: 'Invalid token' });
+  });
+
+  it('returns 401 when post is not found', async () => {
+    process.env.WORDPRESS_PREVIEW_SECRET = 'correct-secret';
+    (getPreviewPost as jest.Mock).mockResolvedValue(null);
+    const req = createMockReq({ secret: 'correct-secret', id: '99' });
+    const res = createMockRes();
+    await handler(req, res);
+    expect(res.status as jest.Mock).toHaveBeenCalledWith(401);
+    expect(res.json as jest.Mock).toHaveBeenCalledWith({ message: 'Post not found' });
+  });
+});

--- a/pages/countries-visited.tsx
+++ b/pages/countries-visited.tsx
@@ -7,7 +7,7 @@ import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
 import WorldMap from '../components/world-map';
 
-const processData = (
+export const processData = (
   rawData: string[][],
 ): Record<string, { country: string; visited: string }[]> => {
   const continents = [

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -37,7 +37,7 @@ const getColourFromTitle = (title: string) => {
 
 const getTextColour = (bg: string) => (lightBackgrounds.has(bg) ? colours.dark : colours.white);
 
-const stripReadMoreParagraph = (excerpt: string) => {
+export const stripReadMoreParagraph = (excerpt: string) => {
   return excerpt.replace(/\s*<a\b[^>]*>.*?<\/a>/gi, '').trim();
 };
 


### PR DESCRIPTION
## Summary

- **`__tests__/countries-visited.test.ts`** (2 tests): Unit tests for the `processData` function — verifies that `'Yes'` maps to `'✔'` and other values map to `''`, and that rows with an empty country column are skipped. `processData` is exported from `pages/countries-visited.tsx` to make it directly testable.
- **`__tests__/tags-tag.test.ts`** (2 tests): Unit tests for `stripReadMoreParagraph` — verifies that anchor tags are stripped from excerpt HTML and that plain text is returned unchanged. The function is exported from `pages/tags/[tag].tsx`.
- **`pages/api/feed.test.ts`** (2 tests): Tests for the RSS feed API handler — confirms a `405` is returned for non-GET requests, and that HTML tags are stripped from post excerpts in the generated RSS XML.
- **`pages/api/preview.test.ts`** (3 tests): Tests for the security-sensitive preview API — confirms `401` is returned when `WORDPRESS_PREVIEW_SECRET` is absent, when the secret param doesn't match the env var, and when the requested post is not found.

All 9 tests pass. The only source changes are minimal `export` additions to two existing functions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uz5Hh5rJWqsmFG1aVzXB5x)_