### PR TITLE
perf: cache stats page at build time and fix useEffect dep anti-patterns

### DIFF
--- a/components/share-bar.tsx
+++ b/components/share-bar.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import styled from '@emotion/styled';
 import { useState } from 'react';
 import { colours } from '../pages/_app';

--- a/pages/favourites-results.tsx
+++ b/pages/favourites-results.tsx
@@ -37,6 +37,9 @@ const FavouriteResults = ({
   const effectiveSortBy = sortBy !== undefined ? sortBy : internalSortBy;
   const showInternalDropdown = sortBy === undefined;
 
+  // Stable primitive key so the effect dependency compares by value, not array identity.
+  const columnsToHideKey = columnsToHide.join('\x00');
+
   // Fetch and apply column-hiding once per sheetId/columnsToHide change.
   // Filter and sort are derived in-memory below — no re-fetch on filter/sort changes.
   useEffect(() => {
@@ -78,7 +81,7 @@ const FavouriteResults = ({
     };
 
     fetchFavouriteData();
-  }, [sheetId, JSON.stringify(columnsToHide)]);
+  }, [sheetId, columnsToHideKey]);
 
   const data = useMemo(() => {
     if (!rawData || rawData.length === 0) return [];

--- a/pages/stats.tsx
+++ b/pages/stats.tsx
@@ -207,7 +207,7 @@ export default function Stats({
   );
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const [
     countriesData,
     booksData,
@@ -255,6 +255,7 @@ export async function getServerSideProps() {
       favouriteCountries: countRows(favouriteCountriesData),
       totalPosts,
     },
+    revalidate: 86400,
   };
 }
 


### PR DESCRIPTION
## Summary

Three targeted performance improvements picked up during the Wednesday performance audit:

### 1. `pages/stats.tsx` — `getServerSideProps` → `getStaticProps` (biggest win)

The Stats page was using `getServerSideProps`, which fired **12 parallel Google Sheets / WordPress API calls on every single page visit**. The data on this page (book counts, beer counts, countries visited, etc.) changes at most once a day.

Switched to `getStaticProps` with `revalidate: 86400`, matching the approach already used by `countries-visited.tsx`. The page now builds once and revalidates in the background at most once per day — visitors always get an instant cached response instead of waiting for 12 upstream requests to resolve.

### 2. `pages/favourites-results.tsx` — replace `JSON.stringify` in `useEffect` deps

The `useEffect` that fetches sheet data used `JSON.stringify(columnsToHide)` as a dependency:

```js
}, [sheetId, JSON.stringify(columnsToHide)]);
```

This is a known anti-pattern: `JSON.stringify` is called on every render, is opaque to exhaustive-deps lint rules, and will silently misbehave if the value is not serialisable. Replaced with a stable primitive string derived by joining the array:

```js
const columnsToHideKey = columnsToHide.join('\x00');
// ...
}, [sheetId, columnsToHideKey]);
```

Same semantics, correct value comparison, lint-friendly.

### 3. `components/share-bar.tsx` — remove no-op `'use client'` directive

This project uses the **Pages Router** (`pages/` directory, no `app/` directory). The `'use client'` directive only has meaning in the App Router. In Pages Router it is silently ignored by Next.js and has no effect. Removing it avoids confusion for anyone reading the codebase and eliminates a misleading signal.

## Test plan

- [ ] Visit `/stats` — page should load instantly (no waterfall of 12 API calls visible in Network tab); data should reflect current sheet values within 24 h of a change
- [ ] Visit any favourites page (e.g. `/favourite-books`) — table should load and sort/filter normally, with no regression in the column-hiding behaviour
- [ ] Verify the share bar renders on post pages and the copy-to-clipboard button works as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6uQuTukPH1L7FLbn4ajZc)_