### PR TITLE
feat: Year in Review page (MVP)

### DIFF
--- a/__tests__/year-in-review-index.test.tsx
+++ b/__tests__/year-in-review-index.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import type { YearInReviewIndexPageProps } from '../lib/types';
+import YearInReviewIndex from '../pages/year-in-review/index';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+jest.mock('../components/layout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../components/post-header', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="post-header">{title}</div>,
+}));
+
+const defaultProps: YearInReviewIndexPageProps = { years: [2025, 2024, 2018] };
+
+describe('YearInReviewIndex', () => {
+  it('renders the post header', () => {
+    render(<YearInReviewIndex {...defaultProps} />);
+    expect(screen.getByTestId('post-header')).toHaveTextContent('Year in Review');
+  });
+
+  it('renders a tile for each year linking to its year-in-review page', () => {
+    render(<YearInReviewIndex {...defaultProps} />);
+    for (const year of defaultProps.years) {
+      const link = screen.getByRole('link', { name: String(year) });
+      expect(link).toHaveAttribute('href', `/year-in-review/${year}`);
+    }
+  });
+});

--- a/__tests__/year-in-review.test.tsx
+++ b/__tests__/year-in-review.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import type { YearInReviewProps } from '../lib/types';
+import YearInReview from '../pages/year-in-review/[year]';
+
+const mockRouter = { isFallback: false };
+
+jest.mock('next/router', () => ({
+  useRouter: () => mockRouter,
+}));
+
+jest.mock('../components/layout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../components/post-header', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="post-header">{title}</div>,
+}));
+
+jest.mock('../components/post-title', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="post-title">{children}</div>
+  ),
+}));
+
+jest.mock('../components/cover-image', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="cover-image">{title}</div>,
+}));
+
+jest.mock('../components/date', () => ({
+  __esModule: true,
+  default: ({ dateString }: { dateString: string }) => <span>{dateString}</span>,
+}));
+
+const mockPost = {
+  id: '1',
+  slug: 'test-post',
+  title: 'Test Post',
+  date: '2025-03-01',
+  excerpt: '<p>A test excerpt</p>',
+  featuredImage: undefined,
+};
+
+const makeProps = (posts: (typeof mockPost)[], year = 2025): YearInReviewProps =>
+  ({ posts, year }) as unknown as YearInReviewProps;
+
+const defaultProps = makeProps([mockPost]);
+
+describe('YearInReview', () => {
+  beforeEach(() => {
+    mockRouter.isFallback = false;
+  });
+
+  it('renders the post header with the correct title', () => {
+    render(<YearInReview {...defaultProps} />);
+    expect(screen.getByTestId('post-header')).toHaveTextContent('2025 Year in Review');
+  });
+
+  it('renders the post count', () => {
+    render(<YearInReview {...defaultProps} />);
+    expect(screen.getByText('1 post written in 2025')).toBeInTheDocument();
+  });
+
+  it('renders a list of posts with correct links', () => {
+    render(<YearInReview {...defaultProps} />);
+    const link = screen.getByRole('link', { name: 'Test Post' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/test-post');
+  });
+
+  it('renders multiple posts', () => {
+    const secondPost = { ...mockPost, id: '2', slug: 'second-post', title: 'Second Post' };
+    render(<YearInReview {...makeProps([mockPost, secondPost])} />);
+    expect(screen.getByText('Test Post')).toBeInTheDocument();
+    expect(screen.getByText('Second Post')).toBeInTheDocument();
+    expect(screen.getByText('2 posts written in 2025')).toBeInTheDocument();
+  });
+
+  it('renders a no-posts message when there are no posts', () => {
+    render(<YearInReview {...makeProps([])} />);
+    expect(screen.getByText('No posts found for 2025')).toBeInTheDocument();
+    expect(screen.getByText('0 posts written in 2025')).toBeInTheDocument();
+  });
+
+  it('links to the previous and next year, but not beyond the first year or the current year', () => {
+    render(<YearInReview {...makeProps([mockPost], 2018)} />);
+    expect(screen.queryByRole('link', { name: /← 2017/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /2019 →/ })).toBeInTheDocument();
+  });
+
+  it('renders a link back to all years', () => {
+    render(<YearInReview {...defaultProps} />);
+    expect(screen.getByRole('link', { name: 'All years' })).toHaveAttribute(
+      'href',
+      '/year-in-review',
+    );
+  });
+
+  it('renders loading state when router.isFallback is true', () => {
+    mockRouter.isFallback = true;
+    render(<YearInReview {...defaultProps} />);
+    expect(screen.getByTestId('post-title')).toHaveTextContent('Loading…');
+  });
+
+  it('does not render the post header when loading', () => {
+    mockRouter.isFallback = true;
+    render(<YearInReview {...defaultProps} />);
+    expect(screen.queryByTestId('post-header')).not.toBeInTheDocument();
+  });
+});

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -86,11 +86,6 @@ export default function Nav() {
           </Link>
         </li>
         <li>
-          <Link href="/year-in-review" onClick={closeNavOnMobile}>
-            Year in Review
-          </Link>
-        </li>
-        <li>
           <Dropdown
             onMouseEnter={() => {
               if (!isMobile) {

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -86,6 +86,11 @@ export default function Nav() {
           </Link>
         </li>
         <li>
+          <Link href="/year-in-review" onClick={closeNavOnMobile}>
+            Year in Review
+          </Link>
+        </li>
+        <li>
           <Dropdown
             onMouseEnter={() => {
               if (!isMobile) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -492,6 +492,37 @@ export async function getPostsByTag(tag: string) {
   return data.posts.nodes;
 }
 
+export async function getPostsByYear(year: number) {
+  const data = await fetchAPI(
+    `
+    query getPostsByYear($year: Int!) {
+      posts(where: { dateQuery: { year: $year } }, first: 100) {
+        nodes {
+          title
+          slug
+          date
+          id
+          excerpt
+          featuredImage {
+            node {
+              sourceUrl
+              mediaDetails {
+                height
+                width
+              }
+              caption
+            }
+          }
+        }
+      }
+    }`,
+    {
+      variables: { year },
+    },
+  );
+  return data.posts.nodes;
+}
+
 export async function getRelatedPosts(tag: string, excludeSlug: string): Promise<RelatedPost[]> {
   const data = await fetchAPI(
     `

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -514,3 +514,12 @@ export type ArchivePageProps = {
 export type TagIndexPageProps = {
   tags: { name: string; count: number }[];
 };
+
+export type YearInReviewProps = {
+  posts: TagsPostProps['posts'];
+  year: number;
+};
+
+export type YearInReviewIndexPageProps = {
+  years: number[];
+};

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -66,6 +66,7 @@ export default function Index({ allPosts, preview }: IndexPageProps) {
       </Container>
       <BrowseTopicsBar>
         <Link href="/tags">Browse all topics →</Link>
+        <Link href="/year-in-review">Year in Review →</Link>
         <RssLink href="/api/feed">Subscribe via RSS</RssLink>
       </BrowseTopicsBar>
       <SearchBar onSearch={handleSearch} />

--- a/pages/now.tsx
+++ b/pages/now.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
 import Container from '../components/container';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
@@ -81,6 +82,10 @@ export default function NowPage() {
                   /now page
                 </a>
                 . If you have one too, I'd love to know.
+              </p>
+              <p>
+                Prefer the bigger picture? Check out the{' '}
+                <Link href="/year-in-review">Year in Review</Link>.
               </p>
             </Footer>
           </NowContent>

--- a/pages/year-in-review/[year].tsx
+++ b/pages/year-in-review/[year].tsx
@@ -1,0 +1,215 @@
+import styled from '@emotion/styled';
+import type { GetStaticPaths, GetStaticProps } from 'next';
+import ErrorPage from 'next/error';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import Container from '../../components/container';
+import CoverImage from '../../components/cover-image';
+import PostDate from '../../components/date';
+import Layout from '../../components/layout';
+import { ContentContainer } from '../../components/post-body';
+import PostHeader from '../../components/post-header';
+import PostTitle from '../../components/post-title';
+import { getPostsByYear } from '../../lib/api';
+import { sanitize } from '../../lib/sanitize';
+import type { YearInReviewProps } from '../../lib/types';
+
+const FIRST_YEAR = 2018;
+
+const stripReadMoreParagraph = (excerpt: string) => {
+  return excerpt.replace(/\s*<a\b[^>]*>.*?<\/a>/gi, '').trim();
+};
+
+export default function YearInReview({ posts, year }: YearInReviewProps) {
+  const router = useRouter();
+
+  if (!router.isFallback && !posts) {
+    return <ErrorPage statusCode={404} />;
+  }
+
+  const seo = {
+    opengraphImage: undefined,
+    opengraphTitle: `${year} Year in Review - World Of Winfield`,
+    opengraphDescription: `A look back at ${year}: everything written on World Of Winfield that year.`,
+    opengraphSiteName: `World Of Winfield`,
+  };
+
+  return (
+    <Layout preview={null} seo={seo} title={`${year} Year in Review`}>
+      <Container>
+        {router.isFallback ? (
+          <PostTitle>Loading…</PostTitle>
+        ) : (
+          <article>
+            <PostHeader title={`${year} Year in Review`} />
+            <ContentContainer>
+              <YearNav aria-label="Year in Review navigation">
+                {year > FIRST_YEAR && (
+                  <Link href={`/year-in-review/${year - 1}`}>← {year - 1}</Link>
+                )}
+                <Link href="/year-in-review">All years</Link>
+                {year < new Date().getFullYear() && (
+                  <Link href={`/year-in-review/${year + 1}`}>{year + 1} →</Link>
+                )}
+              </YearNav>
+              <PostCount>
+                {posts.length} {posts.length === 1 ? 'post' : 'posts'} written in {year}
+              </PostCount>
+              {posts.length === 0 ? (
+                <NoPostsMessage>No posts found for {year}</NoPostsMessage>
+              ) : (
+                posts.map((post) => (
+                  <YearPostCard key={post.id}>
+                    {post.featuredImage && (
+                      <YearPostImageWrapper>
+                        <CoverImage
+                          title={post.title}
+                          coverImage={post.featuredImage}
+                          slug={post.slug}
+                        />
+                      </YearPostImageWrapper>
+                    )}
+                    <YearPostContent>
+                      <YearPostTitle>
+                        <Link href={`/${post.slug}`}>{post.title}</Link>
+                      </YearPostTitle>
+                      <YearPostDate>
+                        <PostDate dateString={post.date} />
+                      </YearPostDate>
+                      {post.excerpt && (
+                        <YearPostExcerpt
+                          dangerouslySetInnerHTML={{
+                            __html: sanitize(stripReadMoreParagraph(post.excerpt)),
+                          }}
+                        />
+                      )}
+                    </YearPostContent>
+                  </YearPostCard>
+                ))
+              )}
+            </ContentContainer>
+          </article>
+        )}
+      </Container>
+    </Layout>
+  );
+}
+
+const YearNav = styled.nav`
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+
+  a {
+    color: inherit;
+    font-weight: bold;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const PostCount = styled.p`
+  font-size: 1rem;
+  color: #666;
+  margin-bottom: 2rem;
+`;
+
+const NoPostsMessage = styled.p`
+  font-size: 1.25rem;
+  padding: 2rem 0;
+  text-align: center;
+`;
+
+const YearPostImageWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 200px;
+  overflow: hidden;
+  flex-shrink: 0;
+
+  @media (min-width: 768px) {
+    width: 240px;
+    height: 160px;
+  }
+`;
+
+const YearPostCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid #eee;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+    gap: 1.5rem;
+    align-items: flex-start;
+  }
+`;
+
+const YearPostContent = styled.div`
+  flex: 1;
+`;
+
+const YearPostTitle = styled.h2`
+  font-size: 1.5rem;
+  margin: 0.75rem 0 0.25rem;
+
+  @media (min-width: 768px) {
+    margin-top: 0;
+  }
+
+  a {
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const YearPostDate = styled.div`
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+`;
+
+const YearPostExcerpt = styled.div`
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #333;
+  margin-bottom: 0.75rem;
+
+  p {
+    margin: 0;
+  }
+`;
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const year = parseInt(params?.year as string, 10);
+  const posts = await getPostsByYear(year);
+
+  return {
+    props: {
+      posts,
+      year,
+    },
+    revalidate: 3600,
+  };
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: currentYear - FIRST_YEAR + 1 }, (_, i) => FIRST_YEAR + i);
+  const paths = years.map((year) => ({ params: { year: String(year) } }));
+  return { paths, fallback: 'blocking' };
+};

--- a/pages/year-in-review/index.tsx
+++ b/pages/year-in-review/index.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
+import Link from 'next/link';
+import Container from '../../components/container';
+import Layout from '../../components/layout';
+import PostHeader from '../../components/post-header';
+import type { YearInReviewIndexPageProps } from '../../lib/types';
+import { colours } from '../_app';
+
+const FIRST_YEAR = 2018;
+
+export default function YearInReviewIndex({ years }: YearInReviewIndexPageProps) {
+  const seo = {
+    opengraphTitle: 'Year in Review - World Of Winfield',
+    opengraphDescription: 'Annual retrospectives of everything written on World Of Winfield.',
+    opengraphSiteName: 'World Of Winfield',
+    opengraphImage: undefined,
+  };
+
+  return (
+    <Layout preview={null} seo={seo} title="Year in Review">
+      <Container>
+        <PostHeader title="Year in Review" />
+        <YearGrid>
+          {years.map((year) => (
+            <YearTile key={year} href={`/year-in-review/${year}`}>
+              {year}
+            </YearTile>
+          ))}
+        </YearGrid>
+      </Container>
+    </Layout>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: currentYear - FIRST_YEAR + 1 }, (_, i) => currentYear - i);
+
+  return {
+    props: { years },
+    revalidate: 3600,
+  };
+};
+
+const YearGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  padding: 2rem 0;
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+`;
+
+const YearTile = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${colours.dark};
+  color: ${colours.white};
+  text-decoration: none;
+  padding: 1.5rem 1rem;
+  min-height: 100px;
+  font-family: 'Oswald', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 0.85;
+  }
+`;


### PR DESCRIPTION
## Summary
- Adds an MVP of the Year in Review page requested in #473: `/year-in-review` (index of years) and `/year-in-review/[year]` (posts written that year), statically generated with `getStaticPaths`/`getStaticProps`, following the existing `pages/tags/[tag].tsx` + `pages/tags/index.tsx` pattern.
- Adds `getPostsByYear(year)` to `lib/api.ts`, using WPGraphQL's `dateQuery: { year }` filter.
- Adds a "Year in Review" nav link next to "The Blog".
- Scoped as **Writing only** for this first pass — the issue notes the Google Sheets travel/favourites data has no year column to slice by, so those sections are follow-up work once the sheets support it.

Closes #473 (MVP scope — travel/favourites/goals sections to follow in later PRs).

## Test plan
- [x] `yarn jest` — all 269 tests pass, including new `__tests__/year-in-review.test.tsx` and `__tests__/year-in-review-index.test.tsx`
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn lint` — clean