### PR TITLE
docs: triage open issues (2026-07-14)

### DIFF
--- a/docs/triage/2026-07-14-issue-triage.md
+++ b/docs/triage/2026-07-14-issue-triage.md
@@ -1,0 +1,75 @@
+# Issue triage — 2026-07-14
+
+Review of all open issues at time of triage.
+
+## #514 — feat: Visual cover art cards for Favourites lists
+
+- **Type:** Feature
+- **Priority:** Medium
+- **Status:** Needs design/implementation work, not started
+
+Well-scoped proposal to replace the plain-table Favourites list pages with
+cover-art card/grid layouts, sourced from free public APIs (Open Library,
+TMDB, MusicBrainz, etc.) and resolved server-side during `getStaticProps`.
+The issue already lays out a sensible phased approach:
+
+- Phase 1 (recommended starting point): Books, Movies, Tracks — reliable,
+  well-documented free APIs, and these are the most-visited lists.
+- Phase 2: DJs, Cities, Countries, Holiday Wish List.
+- Phase 3: Beers, Cheese, Restaurants, Articles — less reliable cover
+  sources, lower payoff.
+
+**Follow-up:** no code changes proposed as part of this triage pass — this
+is a multi-page feature (new data-fetching logic, new card components,
+image fallback handling) that warrants its own dedicated PR(s) per phase
+rather than a partial implementation bundled into a triage change. Phase 1
+is a good candidate for the next feature PR.
+
+## #503 — feat: interactive world map for Countries Visited (with holiday wish list overlay)
+
+- **Type:** Feature
+- **Priority:** Low (re-scoped down from the original ask — see below)
+- **Status:** Core feature already shipped; remaining scope is smaller than the issue describes
+
+The core ask — an interactive SVG world map highlighting visited countries,
+replacing the old continent-grouped text list — has already been
+implemented and merged (PR #505, `components/world-map.tsx` /
+`pages/countries-visited.tsx`), using `react-simple-maps` +
+`world-atlas`, hosted locally, with hover tooltips, zoom controls, and a
+name-normalisation map for Google Sheets ↔ Natural Earth mismatches, plus
+the stat bar and the original list retained below the map for
+accessibility.
+
+Two pieces of the original ask are **not** yet implemented:
+
+1. **Holiday wish-list overlay** — `WorldMap` currently only accepts
+   `visitedCountries`; there's no second colour tier for wish-list
+   countries, and `/holiday-wish-list` data isn't wired into
+   `/countries-visited`.
+2. **Click-through to tag-filtered blog posts** for a visited country.
+
+**Follow-up:** recommend narrowing this issue's scope to just the
+wish-list overlay (smallest, highest-value remaining piece) and either
+dropping the click-through as a separate low-priority idea or spinning it
+into its own issue, since the map itself is done. Left a comment on the
+issue with this context rather than closing it outright, since the
+click-through piece may still be wanted.
+
+## #85 — Dependency Dashboard (Renovate)
+
+- **Type:** Maintenance / Dependencies
+- **Priority:** Low (routine housekeeping)
+- **Status:** Bot-managed, long-running meta-issue — not a new issue to triage
+
+This is Renovate's standing dashboard, not a discrete bug/feature report.
+Currently tracking one blocked PR (`typescript` v7, blocked by a closed
+PR — #513) and one awaiting-schedule update (`actions/setup-node` v7). No
+action needed from this triage pass; left as-is for Renovate to manage.
+
+## Summary
+
+| # | Title | Type | Priority |
+|---|-------|------|----------|
+| 514 | Visual cover art cards for Favourites lists | Feature | Medium |
+| 503 | Interactive world map for Countries Visited | Feature | Low (mostly shipped) |
+| 85 | Dependency Dashboard | Maintenance | Low |


### PR DESCRIPTION
## Summary

Triage pass over all currently open issues in this repo.

| # | Title | Type | Priority | Notes |
|---|-------|------|----------|-------|
| [#514](https://github.com/jamesthemullet/worldofwinfield-nextjs/issues/514) | Visual cover art cards for Favourites lists | Feature | Medium | Not started; phased plan already in the issue, Phase 1 (Books/Movies/Tracks) is the recommended next PR |
| [#503](https://github.com/jamesthemullet/worldofwinfield-nextjs/issues/503) | Interactive world map for Countries Visited | Feature | Low | Core map already shipped in #505 — only the wish-list overlay + tag-filter click-through remain |
| [#85](https://github.com/jamesthemullet/worldofwinfield-nextjs/issues/85) | Dependency Dashboard | Maintenance | Low | Renovate-managed meta-issue, routine, no action needed |

Full write-up with reasoning for each is in `docs/triage/2026-07-14-issue-triage.md`.

Notably, while triaging #503 I found that the interactive world map it asks for was already built and merged (PR #505, `components/world-map.tsx`), so I left a comment on the issue clarifying what's actually still outstanding (the holiday wish-list colour overlay and click-through to tag-filtered posts) rather than the full map build the issue currently implies.

No functional/code changes in this PR — documentation only.

## Test plan

- [x] `docs/`-only change, no app code touched
- [ ] CI checks (lint, knip, pull request audit) — verifying before marking ready for review


---
_Generated by [Claude Code](https://claude.ai/code/session_01LbDe5cDiTpHpB5XDKbbqmw)_