### PR TITLE
perf: extract shared block-colours utility and consolidate stripExternalLinks

### DIFF
--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -1,15 +1,10 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useMemo } from 'react';
-import { sanitize } from '../lib/sanitize';
+import { sanitize, stripExternalLinks } from '../lib/sanitize';
 import type { HeroPostProps } from '../lib/types';
 import { StyledButton } from './core-components';
 import PostHeader from './post-header';
-
-const stripExternalLinks = (excerpt: string): string => {
-  const regex = /<a\s+(?:[^>]*?\s+)?href="https?:\/\/[^"]*"[^>]*>.*?<\/a>/g;
-  return excerpt.replace(regex, '');
-};
 
 export default function HeroPost({
   title,

--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
+import { blockColours } from '../lib/block-colours';
 import type { JamesImagesProps } from '../lib/types';
 import { colours } from '../pages/_app';
 import { formatDate } from './search-results';
@@ -26,16 +27,6 @@ type HomePageBlockTypes = {
 
 const PLACEHOLDER = 'placeholder';
 const RANDOM_PHOTO = 'random photo';
-
-const blockColours = [
-  colours.pink,
-  colours.green,
-  colours.purple,
-  colours.burgandy,
-  colours.dark,
-  colours.azure,
-  colours.blueish,
-];
 
 export default function HomepageBlock({
   className,

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import DOMPurify from 'dompurify';
 import { useMemo } from 'react';
+import { sanitize } from '../lib/sanitize';
 import type { PostBodyProps } from '../lib/types';
 import { colours } from '../pages/_app';
 
@@ -17,13 +17,10 @@ const resolveDataSrc = (html: string): string =>
     .replace(/\bdata-srcset=/gi, 'srcset=');
 
 export default function PostBody({ content }: PostBodyProps) {
-  const sanitizedContent = useMemo(() => {
-    const resolved = resolveDataSrc(content);
-    if (typeof window === 'undefined') return resolved;
-    return DOMPurify.sanitize(resolved, {
-      ADD_ATTR: ['srcset', 'sizes', 'loading', 'decoding'],
-    }) as string;
-  }, [content]);
+  const sanitizedContent = useMemo(
+    () => sanitize(resolveDataSrc(content), { ADD_ATTR: ['srcset', 'sizes', 'loading', 'decoding'] }),
+    [content],
+  );
   return (
     <ContentContainer>
       <div dangerouslySetInnerHTML={{ __html: sanitizedContent }} />

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -18,7 +18,8 @@ const resolveDataSrc = (html: string): string =>
 
 export default function PostBody({ content }: PostBodyProps) {
   const sanitizedContent = useMemo(
-    () => sanitize(resolveDataSrc(content), { ADD_ATTR: ['srcset', 'sizes', 'loading', 'decoding'] }),
+    () =>
+      sanitize(resolveDataSrc(content), { ADD_ATTR: ['srcset', 'sizes', 'loading', 'decoding'] }),
     [content],
   );
   return (

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -1,22 +1,13 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { useMemo } from 'react';
+import { getColoursFromTitle } from '../lib/block-colours';
 import { sanitize } from '../lib/sanitize';
 import type { PostHeaderProps } from '../lib/types';
 import { colours } from '../pages/_app';
 import CoverImage from './cover-image';
 import Date from './date';
 import PostTitle from './post-title';
-
-const blockColours = [
-  colours.pink,
-  colours.green,
-  colours.purple,
-  colours.burgandy,
-  colours.dark,
-  colours.azure,
-  colours.blueish,
-];
 
 export default function PostHeader({
   title,
@@ -30,17 +21,10 @@ export default function PostHeader({
   const aspectRatio =
     (coverImage?.node.mediaDetails.width ?? 0) / (coverImage?.node.mediaDetails.height ?? 1);
 
-  const { randomColour1, randomColour2 } = useMemo(() => {
-    let hash = 0;
-    const seed = title ?? '';
-    for (let i = 0; i < seed.length; i++) {
-      hash = (hash * 31 + seed.charCodeAt(i)) & 0xffffffff;
-    }
-    const index1 = Math.abs(hash) % blockColours.length;
-    const index2 =
-      (index1 + 1 + (Math.abs(hash >> 4) % (blockColours.length - 1))) % blockColours.length;
-    return { randomColour1: blockColours[index1], randomColour2: blockColours[index2] };
-  }, [title]);
+  const { colour1: randomColour1, colour2: randomColour2 } = useMemo(
+    () => getColoursFromTitle(title ?? ''),
+    [title],
+  );
 
   return (
     <>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -2,25 +2,11 @@ import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useMemo } from 'react';
-import { sanitize } from '../lib/sanitize';
+import { getColourFromTitle } from '../lib/block-colours';
+import { sanitize, stripExternalLinks } from '../lib/sanitize';
 import type { PostPreviewProps } from '../lib/types';
 import { colours } from '../pages/_app';
 import DateComponent from './date';
-
-const blockColours = [
-  colours.pink,
-  colours.green,
-  colours.purple,
-  colours.burgandy,
-  colours.dark,
-  colours.azure,
-  colours.blueish,
-];
-
-const stripExternalLinks = (excerpt: string) => {
-  const regex = /<a\s+(?:[^>]*?\s+)?href="https?:\/\/[^"]*"[^>]*>.*?<\/a>/g;
-  return excerpt.replace(regex, '');
-};
 
 export default function PostPreview({
   title,
@@ -31,13 +17,7 @@ export default function PostPreview({
 }: PostPreviewProps) {
   const sanitizedExcerpt = useMemo(() => sanitize(stripExternalLinks(excerpt)), [excerpt]);
 
-  const fallbackColour = useMemo(() => {
-    let hash = 0;
-    for (let i = 0; i < title.length; i++) {
-      hash = (hash * 31 + title.charCodeAt(i)) & 0xffffffff;
-    }
-    return blockColours[Math.abs(hash) % blockColours.length];
-  }, [title]);
+  const fallbackColour = useMemo(() => getColourFromTitle(title), [title]);
 
   return (
     <CardContainer>

--- a/components/section-separator.tsx
+++ b/components/section-separator.tsx
@@ -1,16 +1,7 @@
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
+import { blockColours } from '../lib/block-colours';
 import { colours } from '../pages/_app';
-
-const blockColours = [
-  colours.pink,
-  colours.green,
-  colours.purple,
-  colours.burgandy,
-  colours.dark,
-  colours.azure,
-  colours.blueish,
-];
 
 export default function SectionSeparator() {
   const [backgroundColour, setBackgroundColour] = useState(blockColours[0]);

--- a/lib/block-colours.ts
+++ b/lib/block-colours.ts
@@ -25,6 +25,7 @@ export function getColourFromTitle(title: string): string {
 export function getColoursFromTitle(title: string): { colour1: string; colour2: string } {
   const hash = hashString(title);
   const index1 = Math.abs(hash) % blockColours.length;
-  const index2 = (index1 + 1 + (Math.abs(hash >> 4) % (blockColours.length - 1))) % blockColours.length;
+  const index2 =
+    (index1 + 1 + (Math.abs(hash >> 4) % (blockColours.length - 1))) % blockColours.length;
   return { colour1: blockColours[index1], colour2: blockColours[index2] };
 }

--- a/lib/block-colours.ts
+++ b/lib/block-colours.ts
@@ -1,0 +1,30 @@
+import { colours } from '../pages/_app';
+
+export const blockColours = [
+  colours.pink,
+  colours.green,
+  colours.purple,
+  colours.burgandy,
+  colours.dark,
+  colours.azure,
+  colours.blueish,
+];
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 31 + str.charCodeAt(i)) & 0xffffffff;
+  }
+  return hash;
+}
+
+export function getColourFromTitle(title: string): string {
+  return blockColours[Math.abs(hashString(title)) % blockColours.length];
+}
+
+export function getColoursFromTitle(title: string): { colour1: string; colour2: string } {
+  const hash = hashString(title);
+  const index1 = Math.abs(hash) % blockColours.length;
+  const index2 = (index1 + 1 + (Math.abs(hash >> 4) % (blockColours.length - 1))) % blockColours.length;
+  return { colour1: blockColours[index1], colour2: blockColours[index2] };
+}

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -4,3 +4,7 @@ export function sanitize(html: string, config?: DOMPurify.Config): string {
   if (typeof window === 'undefined') return html;
   return DOMPurify.sanitize(html, config) as string;
 }
+
+export function stripExternalLinks(html: string): string {
+  return html.replace(/<a\s+(?:[^>]*?\s+)?href="https?:\/\/[^"]*"[^>]*>.*?<\/a>/g, '');
+}


### PR DESCRIPTION
## Summary

This PR eliminates code duplication identified during a Wednesday performance & Next.js optimisation audit. The same `blockColours` constant was defined independently in four components, and the same `stripExternalLinks` regex function was duplicated in two components. `post-body` also imported DOMPurify directly when a shared utility already encapsulated that logic.

### Changes

- **New `lib/block-colours.ts`** — single source of truth for the `blockColours` array and two title-hash helpers (`getColourFromTitle`, `getColoursFromTitle`). Removes the identical constant from `post-header`, `post-preview`, `homepage-block`, and `section-separator`, and removes the duplicated hash-to-colour logic from `post-header` and `post-preview`.

- **`lib/sanitize.ts`** — exports a new `stripExternalLinks` utility, removing the identical function that was separately defined in `hero-post` and `post-preview`.

- **`components/post-body.tsx`** — simplified to use `sanitize` from `lib/sanitize` instead of importing DOMPurify directly. The manual `typeof window === 'undefined'` guard is removed because the shared utility already handles it.

### Why

Duplicate module-level constants and functions increase bundle size when the bundler cannot deduplicate them across module boundaries. More importantly, having the same logic in multiple places creates maintenance risk — a future colour change or regex fix would need to be made in several files. Centralising these into `lib/` makes the codebase leaner and the intent clearer.

All 36 affected tests pass; TypeScript reports no errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMktkLThfXD7HcnGhgJjLc)_