### PR TITLE
fix: retry WordPress API fetches on transient/non-JSON responses

### DIFF
--- a/lib/api.test.ts
+++ b/lib/api.test.ts
@@ -10,7 +10,13 @@ const mockFetch = jest.fn();
 global.fetch = mockFetch as typeof fetch;
 
 function gqlSuccess(data: Record<string, unknown>) {
-  return { json: () => Promise.resolve({ data }) };
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => 'application/json' },
+    json: () => Promise.resolve({ data }),
+  };
 }
 
 beforeAll(() => {
@@ -30,10 +36,46 @@ describe('fetchAPI (via exported functions)', () => {
   it('throws "Failed to fetch API" when the response contains GraphQL errors', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
     mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'application/json' },
       json: () => Promise.resolve({ errors: [{ message: 'Not found' }] }),
     });
     await expect(searchBlogPosts('x')).rejects.toThrow('Failed to fetch API');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     jest.restoreAllMocks();
+  });
+
+  it('retries when the API returns a non-JSON (e.g. HTML error) response, then succeeds', async () => {
+    const nodes = [{ slug: 'a', title: 'A', date: '2024-01-01', excerpt: '' }];
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        headers: { get: () => 'text/html' },
+        json: () => Promise.reject(new Error('should not be called')),
+      })
+      .mockResolvedValueOnce(gqlSuccess({ posts: { nodes } }));
+
+    const result = await searchBlogPosts('query');
+
+    expect(result).toEqual(nodes);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting retries when the API keeps returning non-JSON responses', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: { get: () => 'text/html' },
+      json: () => Promise.reject(new Error('should not be called')),
+    });
+
+    await expect(searchBlogPosts('x')).rejects.toThrow(/502/);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
   it('includes Authorization header when WORDPRESS_AUTH_REFRESH_TOKEN is set', async () => {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -6,6 +6,13 @@ type FetchAPIOptions = {
   variables?: Record<string, unknown>;
 };
 
+const MAX_FETCH_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 500;
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function fetchAPI(query = '', { variables }: FetchAPIOptions = {}) {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
@@ -14,21 +21,44 @@ async function fetchAPI(query = '', { variables }: FetchAPIOptions = {}) {
   }
 
   const apiUrl = (process.env.WORDPRESS_API_URL ?? API_URL) as string;
-  const res = await fetch(apiUrl, {
-    headers,
-    method: 'POST',
-    body: JSON.stringify({
-      query,
-      variables,
-    }),
-  });
 
-  const json = await res.json();
-  if (json.errors) {
-    console.error(json.errors);
-    throw new Error('Failed to fetch API');
+  let lastError: Error = new Error('Failed to fetch API');
+
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+    let res: Response;
+    try {
+      res = await fetch(apiUrl, {
+        headers,
+        method: 'POST',
+        body: JSON.stringify({
+          query,
+          variables,
+        }),
+      });
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt < MAX_FETCH_ATTEMPTS) await wait(attempt * RETRY_DELAY_MS);
+      continue;
+    }
+
+    const contentType = res.headers.get('content-type') ?? '';
+    if (!res.ok || !contentType.includes('application/json')) {
+      lastError = new Error(
+        `WordPress API request failed: ${res.status} ${res.statusText} (content-type: ${contentType || 'unknown'})`,
+      );
+      if (attempt < MAX_FETCH_ATTEMPTS) await wait(attempt * RETRY_DELAY_MS);
+      continue;
+    }
+
+    const json = await res.json();
+    if (json.errors) {
+      console.error(json.errors);
+      throw new Error('Failed to fetch API');
+    }
+    return json.data;
   }
-  return json.data;
+
+  throw lastError;
 }
 
 export async function getPreviewPost(id: string, idType = 'DATABASE_ID') {


### PR DESCRIPTION
## Summary

Fixes #523 (Axe tests failing on CI).

Investigated the last ~10 CI runs of the `axe` job — every failure had the same root cause: the `Run yarn run build` step crashed with an unhandled `SyntaxError: Unexpected token '<' ... is not valid JSON`, which comes from `lib/api.ts`'s `fetchAPI` calling `res.json()` unconditionally. `next build` fetches real content from the live `https://blog.worldofwinfield.co.uk/graphql` endpoint during static generation, and when that endpoint intermittently returns a non-JSON response (e.g. a 502/HTML error page, or a rate limit), the build aborts entirely — so the axe accessibility test never even runs (its steps show as `skipped`).

## Changes

- `fetchAPI` now checks `res.ok` and the `content-type` header before parsing JSON, and retries up to 3 times with backoff (500ms/1000ms) on transient failures (network errors, non-2xx status, or non-JSON responses).
- Genuine GraphQL errors (a valid JSON response with an `errors` field) still fail immediately without retrying, since retrying wouldn't help there.
- Updated `lib/api.test.ts` mocks to include `ok`/`status`/`headers` fields, and added tests covering: retry-then-succeed on a non-JSON response, and throwing after exhausting retries.

## Test plan

- [x] `yarn test` — all 273 tests pass (44 suites)
- [x] `yarn lint` (`tsc --noEmit && biome check .`) — passes
- [x] Reviewed CI history across the last 10+ failed runs on `main`-targeting PRs and confirmed they all share this exact failure signature (`Failed to collect page data for /[slug]` / `/tags/[tag]`, preceded by a JSON parse `SyntaxError`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxPmSxWELVcdMbji5XQibN)_