### PR TITLE
fix(a11y): fix accessibility and SEO issues across the site

### DIFF
--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { type JSX, useMemo } from 'react';
 import { sanitize, stripExternalLinks } from '../lib/sanitize';
 import type { HeroPostProps } from '../lib/types';
-import { StyledButton } from './core-components';
+import { colours } from '../pages/_app';
 import PostHeader from './post-header';
 
 export default function HeroPost({
@@ -32,11 +32,9 @@ export default function HeroPost({
         </div>
         <StyledExcerptContainer>
           <StyledExcerpt dangerouslySetInnerHTML={{ __html: sanitizedExcerpt }} />
-          <StyledButton>
-            <Link href={slug} aria-label={`Read more about ${title}`}>
-              Read More
-            </Link>
-          </StyledButton>
+          <ReadMoreLink href={slug} aria-label={`Read more about ${title}`}>
+            Read More
+          </ReadMoreLink>
         </StyledExcerptContainer>
       </div>
     </StyledSection>
@@ -63,6 +61,31 @@ const StyledExcerpt = styled.div`
 
   p {
     word-wrap: break-word;
+  }
+`;
+
+const ReadMoreLink = styled(Link)`
+  display: inline-block;
+  padding: 10px;
+  font-size: 1rem;
+  min-width: 100px;
+  background-color: ${colours.pink};
+  color: ${colours.white};
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
+
+  &:hover {
+    color: ${colours.dark};
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 768px) {
+    flex: 1;
   }
 `;
 

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -35,7 +35,7 @@ export default function Meta({
     <Head>
       <title>{title || opengraphTitle}</title>
       <link rel="canonical" href={canonicalUrl} />
-      <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+      <link rel="apple-touch-icon" sizes="152x152" href="/favicon/apple-touch-icon-152x152.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
       <link rel="mask-icon" href="/favicon/safari-pinned-tab.svg" color="#000000" />

--- a/components/tags.tsx
+++ b/components/tags.tsx
@@ -12,9 +12,7 @@ export default function Tags({ tags }: TagsProps): JSX.Element {
         Tagged:
         {filteredEdges.map((tag, index) => (
           <span key={index}>
-            <Link href={`/tags/${encodeURIComponent(tag.node.name)}`} aria-label={tag.node.name}>
-              {tag.node.name}
-            </Link>
+            <Link href={`/tags/${encodeURIComponent(tag.node.name)}`}>{tag.node.name}</Link>
             {index !== filteredEdges.length - 1 && ',\u00A0'}
           </span>
         ))}

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -47,6 +47,7 @@ export default function Custom404() {
     <Layout preview={null} seo={seo} title="404 - Page Not Found">
       <Container>
         <article>
+          <VisuallyHidden>Page Not Found</VisuallyHidden>
           <Grid>
             {words.map((word, index) => (
               <Block backgroundColour={shuffledColours[index]} key={index}>
@@ -63,6 +64,18 @@ export default function Custom404() {
     </Layout>
   );
 }
+
+const VisuallyHidden = styled.h1`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
 
 const Grid = styled.div`
   display: grid;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -15,6 +15,7 @@ export default function MyDocument({ emotionStyleTags }: { emotionStyleTags: Rea
   return (
     <Html lang="en">
       <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link
           rel="preload"
           href="/fonts/Oswald-VariableFont_rght.ttf"

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -64,7 +64,7 @@ export default function Index({ allPosts, preview }: IndexPageProps) {
           </LoadMoreContainer>
         )}
       </Container>
-      <BrowseTopicsBar>
+      <BrowseTopicsBar aria-label="Blog navigation">
         <Link href="/tags">Browse all topics →</Link>
         <Link href="/year-in-review">Year in Review →</Link>
         <RssLink href="/api/feed">Subscribe via RSS</RssLink>
@@ -84,7 +84,7 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
   };
 };
 
-const BrowseTopicsBar = styled.div`
+const BrowseTopicsBar = styled.nav`
   text-align: center;
   padding: 1rem 0;
 

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -37,6 +37,7 @@ export default function Post({ posts }: PostsProps) {
           <PostTitle>Loading…</PostTitle>
         ) : (
           <>
+            <PageHeading>Posts About Goals</PageHeading>
             {posts.map((post, index) => (
               <PostContainer key={post.id} isEven={index % 2 === 0}>
                 <StyledPostHeader>
@@ -87,6 +88,18 @@ export const getStaticProps: GetStaticProps = async () => {
     revalidate: 3600,
   };
 };
+
+const PageHeading = styled.h1`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
 
 const ExcerptArea = styled.div`
   width: calc(50% - 4rem);

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -37,6 +37,7 @@ export default function Post({ posts }: PostsProps) {
           <PostTitle>Loading…</PostTitle>
         ) : (
           <>
+            <PageHeading>Posts About Music</PageHeading>
             {posts.map((post, index) => (
               <PostContainer key={post.id} isEven={index % 2 === 0}>
                 <StyledPostHeader>
@@ -87,6 +88,18 @@ export const getStaticProps: GetStaticProps = async () => {
     revalidate: 3600,
   };
 };
+
+const PageHeading = styled.h1`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
 
 const ExcerptArea = styled.div`
   width: calc(50% - 4rem);

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -37,6 +37,7 @@ export default function Post({ posts }: PostsProps) {
           <PostTitle>Loading…</PostTitle>
         ) : (
           <>
+            <PageHeading>Posts About Politics</PageHeading>
             {posts.map((post, index) => (
               <PostContainer key={post.id} isEven={index % 2 === 0}>
                 <StyledPostHeader>
@@ -87,6 +88,18 @@ export const getStaticProps: GetStaticProps = async () => {
     revalidate: 3600,
   };
 };
+
+const PageHeading = styled.h1`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
 
 const ExcerptArea = styled.div`
   width: calc(50% - 4rem);

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -52,7 +52,7 @@ export default function Post({ posts, tag }: TagsPostProps) {
   const seo = {
     opengraphImage: undefined,
     opengraphTitle: `Posts tagged with ${tag} - World Of Winfield`,
-    opengraphDescription: `Posts tagged with ${tag} - World Of Winfield`,
+    opengraphDescription: `Browse all posts tagged with "${tag}" on World Of Winfield.`,
     opengraphSiteName: `World Of Winfield`,
   };
 

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -37,6 +37,7 @@ export default function Post({ posts }: PostsProps) {
           <PostTitle>Loading…</PostTitle>
         ) : (
           <>
+            <PageHeading>Posts About Travel</PageHeading>
             {posts.map((post, index) => (
               <PostContainer key={post.id} isEven={index % 2 === 0}>
                 <StyledPostHeader>
@@ -89,6 +90,18 @@ export const getStaticProps: GetStaticProps = async () => {
     revalidate: 3600,
   };
 };
+
+const PageHeading = styled.h1`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
 
 const ExcerptArea = styled.div`
   width: calc(50% - 4rem);


### PR DESCRIPTION
## Summary

Scheduled accessibility & SEO audit for Thursday 2026-07-16. Fixed the highest-impact issues found across the codebase.

### Priority 1 — Functional breakage / serious violations

- **`pages/_document.tsx`** — Added missing `<meta name="viewport">` tag. Without it, mobile browsers render the page at desktop width, breaking responsive design and hurting Core Web Vitals. Next.js Pages Router with a custom `_document.tsx` does **not** inject this automatically.

- **`components/hero-post.tsx`** — Replaced invalid `<button><a>` nesting (a `StyledButton` wrapping a `<Link>`) with a proper `ReadMoreLink` styled anchor. Nesting interactive elements is invalid HTML5 and causes inconsistent behaviour across browsers and screen readers. Moved the button styles into a local `styled(Link)`.

- **`components/meta.tsx`** — Fixed broken `apple-touch-icon` href pointing to `/favicon/apple-touch-icon.png`, which does not exist in `public/favicon/`. Updated to reference the existing `apple-touch-icon-152x152.png`.

### Priority 2 — Significant accessibility gaps

- **`pages/travel.tsx`, `pages/music.tsx`, `pages/politics.tsx`, `pages/goals.tsx`** — All post cards on these pages used `headingLevel="h2"`, leaving the page body with no `<h1>` at all. Added a visually-hidden `<h1>` (using the standard SR-only clip technique) before the post list so screen readers and crawlers find a page-level heading.

- **`pages/404.tsx`** — The 404 page had no heading element whatsoever. Added a visually-hidden `<h1>Page Not Found</h1>` inside the `<article>`.

- **`pages/blog.tsx`** — Changed `BrowseTopicsBar` from `styled.div` to `styled.nav` and added `aria-label="Blog navigation"`. A `<div>` containing navigation links provides no landmark for screen reader users.

### Priority 3 — SEO and minor improvements

- **`pages/tags/[tag].tsx`** — `opengraphDescription` was identical to `opengraphTitle`, giving search engines nothing useful for the snippet. Now reads `Browse all posts tagged with "{tag}" on World Of Winfield.`

- **`components/tags.tsx`** — Removed redundant `aria-label` from tag links whose visible text already provides the accessible name. The duplicate attribute is harmless but adds noise and could override future text changes silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVJbsKuaJo4V9qmMRxH2a6)_