### PR TITLE
fix(test): match goals read-more link by its accessible name

### DIFF
--- a/__tests__/goals.test.tsx
+++ b/__tests__/goals.test.tsx
@@ -90,7 +90,7 @@ describe('GoalsPage', () => {
 
   it('renders posts with a read-more link to the post slug', () => {
     render(<GoalsPage posts={[mockPost]} />);
-    const link = screen.getByRole('link', { name: 'Read this post →' });
+    const link = screen.getByRole('link', { name: 'Read more about My Goals Post' });
     expect(link).toHaveAttribute('href', '/my-goals-post');
   });
 


### PR DESCRIPTION
## Summary

Fixes a broken test on `main` that's currently failing the `unit_tests` CI check on every PR (surfaced while babysitting #528, which is unrelated to this fix).

- `pages/goals.tsx`'s read-more link has both visible text (`Read this post →`) and `aria-label={`Read more about ${post.title}`}`. Per accessible-name computation rules, the `aria-label` wins over visible text content.
- The `aria-label` was added in #512 (`fix(a11y): fix accessibility and SEO issues across site`) without updating this test, so `getByRole('link', { name: 'Read this post →' })` has been failing since.
- Updated the query to match the actual accessible name (`Read more about My Goals Post`), which is also the more meaningful assertion — it makes sure the per-post label is being rendered correctly, not just static text.

Checked for the same pattern elsewhere — this is the only test asserting on that literal string.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `biome check` — clean
- [x] `jest` — full suite (51 suites / 291 tests) passes, including the previously-failing `goals.test.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2UuYmBW4qfroJkViCB91v)_