### PR TITLE
feat: add live text search to Favourites tables

### DIFF
--- a/pages/favourites-results.test.tsx
+++ b/pages/favourites-results.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
+import FavouriteResults from './favourites-results';
+
+jest.mock('../lib/sheets', () => ({
+  fetchDataFromGoogleSheets: jest.fn(),
+}));
+
+const mockedFetchData = fetchDataFromGoogleSheets as jest.MockedFunction<
+  typeof fetchDataFromGoogleSheets
+>;
+
+const sheetData = [
+  ['Title', 'Author', 'Score'],
+  ['The Hobbit', 'J.R.R. Tolkien', '9'],
+  ['Dune', 'Frank Herbert', '10'],
+  ['Neuromancer', 'William Gibson', '8'],
+];
+
+describe('FavouriteResults search', () => {
+  beforeEach(() => {
+    mockedFetchData.mockReset();
+    mockedFetchData.mockResolvedValue(sheetData);
+  });
+
+  it('renders a labelled search input once data has loaded', async () => {
+    render(<FavouriteResults sheetId="sheet-id" />);
+    await waitFor(() => expect(screen.getByLabelText('Search')).toBeInTheDocument());
+  });
+
+  it('filters rows to those matching the search query', async () => {
+    render(<FavouriteResults sheetId="sheet-id" />);
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Search'), { target: { value: 'gibson' } });
+
+    expect(screen.getByText('Neuromancer')).toBeInTheDocument();
+    expect(screen.queryByText('Dune')).not.toBeInTheDocument();
+    expect(screen.queryByText('The Hobbit')).not.toBeInTheDocument();
+  });
+
+  it('matches substrings case-insensitively across any column', async () => {
+    render(<FavouriteResults sheetId="sheet-id" />);
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Search'), { target: { value: 'HOB' } });
+
+    expect(screen.getByText('The Hobbit')).toBeInTheDocument();
+    expect(screen.queryByText('Dune')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state and restores the full list when the query is cleared', async () => {
+    render(<FavouriteResults sheetId="sheet-id" />);
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Search'), { target: { value: 'no such book' } });
+    expect(screen.getByText(/No results for/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search'), { target: { value: '' } });
+    expect(screen.queryByText(/No results for/)).not.toBeInTheDocument();
+    expect(screen.getByText('Dune')).toBeInTheDocument();
+    expect(screen.getByText('The Hobbit')).toBeInTheDocument();
+    expect(screen.getByText('Neuromancer')).toBeInTheDocument();
+  });
+
+  it('combines with an active genre filter', async () => {
+    const genreData = [
+      ['Title', 'Genre'],
+      ['Song A', 'House'],
+      ['Song B', 'Techno'],
+      ['Song C', 'House'],
+    ];
+    mockedFetchData.mockResolvedValue(genreData);
+
+    render(<FavouriteResults sheetId="sheet-id" genreFilter="House" />);
+    await waitFor(() => expect(screen.getByText('Song A')).toBeInTheDocument());
+    expect(screen.getByText('Song C')).toBeInTheDocument();
+    expect(screen.queryByText('Song B')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search'), { target: { value: 'song a' } });
+
+    expect(screen.getByText('Song A')).toBeInTheDocument();
+    expect(screen.queryByText('Song C')).not.toBeInTheDocument();
+  });
+});

--- a/pages/favourites-results.tsx
+++ b/pages/favourites-results.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useEffect, useMemo, useState } from 'react';
+import { StyledInput } from '../components/core-components';
 import SortDropdown from '../components/SortDropdown';
 import { fetchDataFromGoogleSheets } from '../lib/sheets';
 
@@ -33,6 +34,7 @@ const FavouriteResults = ({
   const [loading, setLoading] = useState(false);
   const [internalSortBy, setInternalSortBy] = useState('');
   const [sortColumns, setSortColumns] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
 
   const effectiveSortBy = sortBy !== undefined ? sortBy : internalSortBy;
   const showInternalDropdown = sortBy === undefined;
@@ -83,11 +85,19 @@ const FavouriteResults = ({
     fetchFavouriteData();
   }, [sheetId, columnsToHideKey]);
 
+  const trimmedQuery = searchQuery.trim().toLowerCase();
+
   const data = useMemo(() => {
     if (!rawData || rawData.length === 0) return [];
 
     const headerRow = rawData[0];
     let filteredRows = rawData.slice(1);
+
+    if (trimmedQuery) {
+      filteredRows = filteredRows.filter((row: string[]) =>
+        row.some((cell) => (cell ?? '').toString().toLowerCase().includes(trimmedQuery)),
+      );
+    }
 
     if (genreFilter && headerRow.includes('Genre')) {
       const genreIndex = headerRow.indexOf('Genre');
@@ -148,16 +158,33 @@ const FavouriteResults = ({
     }
 
     return [headerRow, ...filteredRows];
-  }, [rawData, genreFilter, labelFilter, effectiveSortBy]);
+  }, [rawData, trimmedQuery, genreFilter, labelFilter, effectiveSortBy]);
+
+  const hasRows = rawData !== null && rawData.length > 1;
 
   return (
     <FavouritesContainer>
+      {hasRows && (
+        <SearchContainer>
+          <label htmlFor="favourites-search-input">Search</label>
+          <StyledInput
+            id="favourites-search-input"
+            type="text"
+            placeholder="Search..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </SearchContainer>
+      )}
       {showInternalDropdown && sortColumns.length > 0 && (
         <SortDropdown
           options={sortColumns}
           selected={internalSortBy}
           onChange={setInternalSortBy}
         />
+      )}
+      {hasRows && data.length === 1 && trimmedQuery && (
+        <NoResults>No results for &ldquo;{searchQuery.trim()}&rdquo;</NoResults>
       )}
       <StyledTable>
         {data.length > 0 && (
@@ -230,6 +257,21 @@ export default FavouriteResults;
 const FavouritesContainer = styled.div`
   margin: 20px;
   overflow-x: auto;
+`;
+
+const SearchContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: 10px;
+
+  label {
+    margin-bottom: 4px;
+  }
+`;
+
+const NoResults = styled.p`
+  margin: 20px 0;
 `;
 
 const StyledTable = styled.table`


### PR DESCRIPTION
## Summary

Closes #530.

Adds a live text search input to `FavouriteResults` (`pages/favourites-results.tsx`), the shared component behind all 10 Favourites pages (books, movies, DJs, beers, cheese, restaurants, cities, countries, articles, tracks).

- Added a `searchQuery` state and a labelled `StyledInput` (from `core-components`), rendered above the table once data has loaded.
- Filtering is a substring, case-insensitive match against every visible cell in a row, applied before the existing genre/label filters and sort — all three work together simultaneously.
- Clearing the input restores the full list.
- Added a "No results for '…'" empty state, shown only when a search query yields zero rows.
- Since `FavouriteResults` is shared across all 10 categories, this is a single write-once change — no per-page edits needed.

## Why

Every Favourites page is a full table with no way to look something up quickly (e.g. "has James rated Guinness?"). This is especially painful on mobile with long tables. The component already does all filtering in-memory via `useMemo`, so a text filter is a small, self-contained addition to the existing pipeline.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on changed files — clean
- [x] New tests in `pages/favourites-results.test.tsx` (5 tests): labelled input renders once data loads, filters rows by query, case-insensitive substring match across columns, empty state + restore-on-clear, and combining search with an active genre filter
- [x] Full `jest` suite (52 suites / 296 tests) passes with no regressions


---
_Generated by [Claude Code](https://claude.ai/code/session_01QkijGmKbmSECbAjskZfFLY)_