### PR TITLE
test: add unit tests for stocks utility functions and tags index page

### DIFF
--- a/__tests__/stocks.test.ts
+++ b/__tests__/stocks.test.ts
@@ -1,0 +1,97 @@
+import {
+  getChange,
+  normalisePrices,
+  normaliseSymbolAlias,
+  sortByPercentChange,
+} from '../pages/stocks';
+
+describe('normaliseSymbolAlias', () => {
+  it('normalises exchange aliases to canonical form and strips trailing dots', () => {
+    expect(normaliseSymbolAlias('LSE:GAW')).toBe('XLON:GAW');
+    expect(normaliseSymbolAlias('XLON:TW.')).toBe('XLON:TW');
+    expect(normaliseSymbolAlias('NYSE:NVO')).toBe('XNYS:NVO');
+    expect(normaliseSymbolAlias('NASDAQ:RYAAY')).toBe('XNAS:RYAAY');
+    expect(normaliseSymbolAlias('XETRA:PCFP')).toBe('XETR:PCFP');
+    expect(normaliseSymbolAlias(' xlon:gaw ')).toBe('XLON:GAW');
+  });
+
+  it('returns trimmed uppercase input unchanged for unknown exchanges', () => {
+    expect(normaliseSymbolAlias('UNKNOWN:XYZ')).toBe('UNKNOWN:XYZ');
+    expect(normaliseSymbolAlias('NOSEPARATOR')).toBe('NOSEPARATOR');
+  });
+});
+
+describe('normalisePrices', () => {
+  it('returns an empty array for null or non-object input', () => {
+    expect(normalisePrices(null)).toEqual([]);
+    expect(normalisePrices('not an object')).toEqual([]);
+    expect(normalisePrices(42)).toEqual([]);
+  });
+
+  it('converts numeric and string prices to numbers and sets error rows to null', () => {
+    const input = {
+      'XLON:GAW': { price: 150.5, previousClose: 148 },
+      'LSE:FORT': { price: '200', previousClose: '195' },
+      'XLON:EVR': { price: 50, error: 'delisted' },
+    };
+    const rows = normalisePrices(input);
+
+    const gaw = rows.find((r) => r.symbol === 'XLON:GAW');
+    expect(gaw?.price).toBe(150.5);
+    expect(gaw?.previousClose).toBe(148);
+    expect(gaw?.companyName).toBe('Games Workshop Group PLC');
+
+    const fort = rows.find((r) => r.symbol === 'XLON:FORT');
+    expect(fort?.price).toBe(200);
+    expect(fort?.previousClose).toBe(195);
+
+    const evr = rows.find((r) => r.symbol === 'XLON:EVR');
+    expect(evr?.price).toBeNull();
+  });
+});
+
+describe('getChange', () => {
+  it('returns null change and percent when either input is null or baseline is zero', () => {
+    expect(getChange(null, 100)).toEqual({ change: null, percent: null });
+    expect(getChange(100, null)).toEqual({ change: null, percent: null });
+    expect(getChange(100, 0)).toEqual({ change: null, percent: null });
+  });
+
+  it('calculates absolute change and percent change correctly', () => {
+    expect(getChange(110, 100)).toEqual({ change: 10, percent: 10 });
+    expect(getChange(90, 100)).toEqual({ change: -10, percent: -10 });
+  });
+});
+
+describe('sortByPercentChange', () => {
+  const makeRow = (symbol: string, price: number | null, previousClose: number | null = null) => ({
+    symbol,
+    companyName: symbol,
+    price,
+    previousClose,
+    close30DaysAgo: null as number | null,
+    close90DaysAgo: null as number | null,
+    close1YearAgo: null as number | null,
+  });
+
+  it('returns rows in original order when sort mode is default', () => {
+    const rows = [makeRow('B', 110, 100), makeRow('A', 90, 100)];
+    const result = sortByPercentChange(rows, 'default', '1d');
+    expect(result[0].symbol).toBe('B');
+    expect(result[1].symbol).toBe('A');
+  });
+
+  it('sorts by 1-day percent change descending, with null-price rows last', () => {
+    const rows = [
+      makeRow('A', 105, 100),
+      makeRow('B', 120, 100),
+      makeRow('C', null, 100),
+      makeRow('D', 90, 100),
+    ];
+    const result = sortByPercentChange(rows, '1d-desc', '1d');
+    expect(result[0].symbol).toBe('B');
+    expect(result[1].symbol).toBe('A');
+    expect(result[2].symbol).toBe('D');
+    expect(result[3].symbol).toBe('C');
+  });
+});

--- a/__tests__/tags-index.test.tsx
+++ b/__tests__/tags-index.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import TagsIndex from '../pages/tags/index';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    dark: '#291720',
+    white: '#FFFFFF',
+    pink: '#D90368',
+    purple: '#8884FF',
+    burgandy: '#820263',
+    green: '#04A777',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+jest.mock('../components/layout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../components/container', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../components/post-header', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="post-header">{title}</div>,
+}));
+
+const mockTags = [
+  { name: 'JavaScript', count: 5 },
+  { name: 'Travel', count: 1 },
+  { name: 'C#', count: 3 },
+];
+
+describe('TagsIndex', () => {
+  it('renders each tag name as a link with the correct href', () => {
+    render(<TagsIndex tags={mockTags} />);
+
+    const jsLink = screen.getByRole('link', { name: /JavaScript/i });
+    expect(jsLink).toBeInTheDocument();
+    expect(jsLink).toHaveAttribute('href', '/tags/JavaScript');
+
+    const csharpLink = screen.getByRole('link', { name: /C#/i });
+    expect(csharpLink).toHaveAttribute('href', `/tags/${encodeURIComponent('C#')}`);
+  });
+
+  it('shows singular "post" for a count of 1, and plural "posts" otherwise', () => {
+    render(<TagsIndex tags={mockTags} />);
+
+    expect(screen.getByText('5 posts')).toBeInTheDocument();
+    expect(screen.getByText('1 post')).toBeInTheDocument();
+    expect(screen.getByText('3 posts')).toBeInTheDocument();
+  });
+
+  it('renders the page heading', () => {
+    render(<TagsIndex tags={mockTags} />);
+    expect(screen.getByTestId('post-header')).toHaveTextContent('Browse All Topics');
+  });
+});

--- a/pages/stocks.tsx
+++ b/pages/stocks.tsx
@@ -148,7 +148,7 @@ const COMPANY_NAMES: Record<string, string> = {
   'XLON:BRFI': 'BlackRock Frontiers Investment Trust PLC',
 };
 
-const normaliseSymbolAlias = (symbol: string): string => {
+export const normaliseSymbolAlias = (symbol: string): string => {
   const trimmed = symbol.trim().toUpperCase();
   const match = trimmed.match(/^([A-Z]+):(.+)$/);
 
@@ -196,7 +196,7 @@ const resolveDefaultWsUrl = (): string => {
   return `${protocol}://${window.location.hostname}:8081`;
 };
 
-const normalisePrices = (input: unknown): StockRow[] => {
+export const normalisePrices = (input: unknown): StockRow[] => {
   if (!input || typeof input !== 'object') {
     return [];
   }
@@ -288,7 +288,7 @@ const buildConfiguredRows = (symbols: Set<string>, liveRows: StockRow[]): StockR
   });
 };
 
-const getChange = (
+export const getChange = (
   currentPrice: number | null,
   baseline: number | null,
 ): { change: number | null; percent: number | null } => {
@@ -357,7 +357,7 @@ const getSortConfig = (
   return { window, direction };
 };
 
-const sortByPercentChange = (
+export const sortByPercentChange = (
   rows: StockRow[],
   mode: SortMode,
   window: ChangeWindow,


### PR DESCRIPTION
## Summary

- Export four pure utility functions from `pages/stocks.tsx` (`normaliseSymbolAlias`, `normalisePrices`, `getChange`, `sortByPercentChange`) so they can be tested directly without rendering the full page
- Add `__tests__/stocks.test.ts` with 8 test cases covering the core business logic: exchange alias normalisation across all supported prefixes (LSE→XLON, NYSE→XNYS, NASDAQ→XNAS, XETRA→XETR), trailing-dot stripping, price parsing from unknown/null input, null-safe change calculations, and sort-by-percent-change including null-price rows being pushed to the end
- Add `__tests__/tags-index.test.tsx` with 3 test cases for `pages/tags/index.tsx`: tag names render as links with correct hrefs (including `encodeURIComponent` for special characters like `C#`), singular/plural post-count text, and the page heading

## Why

`pages/stocks.tsx` contained the most untested pure-function logic in the entire codebase — seven calculation and normalisation functions with real branching logic but no coverage at all. Exporting and testing them directly gives the highest signal per test added. `pages/tags/index.tsx` was also completely untested despite being a meaningful content-discovery page.

## Test plan

- [ ] `yarn test` passes with 11 new tests (8 in stocks, 3 in tags-index) all green
- [ ] `yarn lint` reports no errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6YFhCxay1u7QiTU6A9ST7)_