### PR TITLE
feat: add live text search to Favourites tables

### DIFF
--- a/__tests__/favourites-results.test.tsx
+++ b/__tests__/favourites-results.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import FavouriteResults from '../pages/favourites-results';
+
+jest.mock('../lib/sheets', () => ({
+  fetchDataFromGoogleSheets: jest.fn(),
+}));
+
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
+
+const mockFetch = fetchDataFromGoogleSheets as jest.Mock;
+
+const sampleData = [
+  ['Title', 'Author', 'Score'],
+  ['Dune', 'Frank Herbert', '9'],
+  ['Neuromancer', 'William Gibson', '8'],
+  ['Foundation', 'Isaac Asimov', '7'],
+];
+
+describe('FavouriteResults search', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(sampleData);
+  });
+
+  it('shows all rows when the search box is empty', async () => {
+    render(<FavouriteResults sheetId="sheet-1" />);
+
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+    expect(screen.getByText('Neuromancer')).toBeInTheDocument();
+    expect(screen.getByText('Foundation')).toBeInTheDocument();
+  });
+
+  it('filters rows in real time as the user types, case-insensitively', async () => {
+    render(<FavouriteResults sheetId="sheet-1" />);
+
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+
+    const searchInput = screen.getByLabelText('Search:');
+    fireEvent.change(searchInput, { target: { value: 'gibson' } });
+
+    expect(screen.getByText('Neuromancer')).toBeInTheDocument();
+    expect(screen.queryByText('Dune')).not.toBeInTheDocument();
+    expect(screen.queryByText('Foundation')).not.toBeInTheDocument();
+  });
+
+  it('matches substrings against any column, not just the first', async () => {
+    render(<FavouriteResults sheetId="sheet-1" />);
+
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+
+    const searchInput = screen.getByLabelText('Search:');
+    fireEvent.change(searchInput, { target: { value: 'asimov' } });
+
+    expect(screen.getByText('Foundation')).toBeInTheDocument();
+    expect(screen.queryByText('Dune')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no matches', async () => {
+    render(<FavouriteResults sheetId="sheet-1" />);
+
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+
+    const searchInput = screen.getByLabelText('Search:');
+    fireEvent.change(searchInput, { target: { value: 'no such book' } });
+
+    expect(screen.getByText(/No results for/)).toBeInTheDocument();
+  });
+
+  it('restores the full list when the search input is cleared', async () => {
+    render(<FavouriteResults sheetId="sheet-1" />);
+
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+
+    const searchInput = screen.getByLabelText('Search:');
+    fireEvent.change(searchInput, { target: { value: 'gibson' } });
+    expect(screen.queryByText('Dune')).not.toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: '' } });
+
+    expect(screen.getByText('Dune')).toBeInTheDocument();
+    expect(screen.getByText('Neuromancer')).toBeInTheDocument();
+    expect(screen.getByText('Foundation')).toBeInTheDocument();
+  });
+});

--- a/pages/favourites-results.tsx
+++ b/pages/favourites-results.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useEffect, useMemo, useState } from 'react';
+import { StyledInput } from '../components/core-components';
 import SortDropdown from '../components/SortDropdown';
 import { fetchDataFromGoogleSheets } from '../lib/sheets';
 
@@ -33,6 +34,7 @@ const FavouriteResults = ({
   const [loading, setLoading] = useState(false);
   const [internalSortBy, setInternalSortBy] = useState('');
   const [sortColumns, setSortColumns] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
 
   const effectiveSortBy = sortBy !== undefined ? sortBy : internalSortBy;
   const showInternalDropdown = sortBy === undefined;
@@ -98,6 +100,13 @@ const FavouriteResults = ({
       filteredRows = filteredRows.filter((row: string[]) => row[labelIndex] === labelFilter);
     }
 
+    if (searchQuery.trim()) {
+      const lowerQuery = searchQuery.trim().toLowerCase();
+      filteredRows = filteredRows.filter((row: string[]) =>
+        row.some((cell) => (cell ?? '').toString().toLowerCase().includes(lowerQuery)),
+      );
+    }
+
     const normalizedHeaders = headerRow.map((h: string) => normalize(h));
 
     const chooseSortColumnIndex = () => {
@@ -148,16 +157,32 @@ const FavouriteResults = ({
     }
 
     return [headerRow, ...filteredRows];
-  }, [rawData, genreFilter, labelFilter, effectiveSortBy]);
+  }, [rawData, genreFilter, labelFilter, searchQuery, effectiveSortBy]);
+
+  const hasRows = rawData !== null && rawData.length > 1;
+  const noSearchResults = hasRows && searchQuery.trim() !== '' && data.length <= 1;
 
   return (
     <FavouritesContainer>
+      <SearchWrapper>
+        <SearchLabel htmlFor="favourites-search">Search:</SearchLabel>
+        <StyledInput
+          id="favourites-search"
+          type="text"
+          placeholder="Search…"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </SearchWrapper>
       {showInternalDropdown && sortColumns.length > 0 && (
         <SortDropdown
           options={sortColumns}
           selected={internalSortBy}
           onChange={setInternalSortBy}
         />
+      )}
+      {noSearchResults && (
+        <EmptyState>No results for &ldquo;{searchQuery.trim()}&rdquo;</EmptyState>
       )}
       <StyledTable>
         {data.length > 0 && (
@@ -230,6 +255,19 @@ export default FavouriteResults;
 const FavouritesContainer = styled.div`
   margin: 20px;
   overflow-x: auto;
+`;
+
+const SearchWrapper = styled.div`
+  margin: 1rem 0;
+  text-align: center;
+`;
+
+const SearchLabel = styled.label`
+  margin-right: 0.5rem;
+`;
+
+const EmptyState = styled.p`
+  text-align: center;
 `;
 
 const StyledTable = styled.table`


### PR DESCRIPTION
## Summary
- Adds a live, case-insensitive text search input to the shared `FavouriteResults` component (`pages/favourites-results.tsx`), which powers all 10 Favourites pages (books, movies, DJs, beers, cheese, restaurants, cities, countries, articles, tracks)
- Filtering matches any visible column and composes with existing sort/genre/label filters
- Shows a "No results for '…'" empty state when a search has no matches
- Closes #530

## Test plan
- [x] `yarn jest __tests__/favourites-results.test.tsx` — 5 new tests covering: default (unfiltered) rendering, case-insensitive filtering, substring matching across any column, empty state, and clearing the search restores the full list
- [x] `yarn jest` — full suite (304 tests) passes
- [x] `yarn tsc --noEmit` — no type errors
- [x] `yarn lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)