### PR TITLE
fix: render Getty Images embeds instead of stripping them

### DIFF
--- a/components/post-body.test.tsx
+++ b/components/post-body.test.tsx
@@ -41,12 +41,24 @@ describe('PostBody', () => {
     expect(container).toBeInTheDocument();
   });
 
-  it('passes content through DOMPurify.sanitize with extended attributes', () => {
+  it('passes content through DOMPurify.sanitize with extended attributes and script tag opt-in', () => {
     render(<PostBody content="<p>Test content</p>" />);
     expect(DOMPurify.sanitize).toHaveBeenCalledWith(
       '<p>Test content</p>',
-      expect.objectContaining({ ADD_ATTR: expect.arrayContaining(['srcset']) }),
+      expect.objectContaining({
+        ADD_TAGS: ['script'],
+        ADD_ATTR: expect.arrayContaining(['srcset', 'async', 'charset']),
+      }),
     );
+  });
+
+  it('re-creates script tags after mount so embeds like Getty execute', () => {
+    const { container } = render(
+      <PostBody content='<script src="https://embed-cdn.gettyimages.com/widgets.js"></script>' />,
+    );
+    const script = container.querySelector('script');
+    expect(script).not.toBeNull();
+    expect(script?.getAttribute('src')).toBe('https://embed-cdn.gettyimages.com/widgets.js');
   });
 
   it('converts data-src to src before sanitizing', () => {

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { type JSX, useMemo } from 'react';
+import { type JSX, useEffect, useMemo, useRef } from 'react';
 import { sanitize } from '../lib/sanitize';
 import type { PostBodyProps } from '../lib/types';
 import { colours } from '../pages/_app';
@@ -17,13 +17,33 @@ const resolveDataSrc = (html: string): string =>
     .replace(/\bdata-srcset=/gi, 'srcset=');
 
 export default function PostBody({ content }: PostBodyProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
   const sanitizedContent = useMemo(
     () =>
-      sanitize(resolveDataSrc(content), { ADD_ATTR: ['srcset', 'sizes', 'loading', 'decoding'] }),
+      sanitize(resolveDataSrc(content), {
+        ADD_TAGS: ['script'],
+        ADD_ATTR: ['srcset', 'sizes', 'loading', 'decoding', 'async', 'charset'],
+      }),
     [content],
   );
+
+  // Browsers don't execute <script> tags inserted via innerHTML, so any script
+  // that survived sanitizing (e.g. Getty's embed widget) has to be re-created here.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    for (const oldScript of Array.from(container.querySelectorAll('script'))) {
+      const newScript = document.createElement('script');
+      for (const { name, value } of Array.from(oldScript.attributes)) {
+        newScript.setAttribute(name, value);
+      }
+      newScript.textContent = oldScript.textContent;
+      oldScript.replaceWith(newScript);
+    }
+  }, [sanitizedContent]);
+
   return (
-    <ContentContainer>
+    <ContentContainer ref={containerRef}>
       <div dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
     </ContentContainer>
   );

--- a/lib/sanitize.test.ts
+++ b/lib/sanitize.test.ts
@@ -26,3 +26,41 @@ describe('sanitize', () => {
     expect(DOMPurify.sanitize).toHaveBeenCalledWith('<b>bold</b>', config);
   });
 });
+
+describe('sanitize with real DOMPurify', () => {
+  // Import the real module (not the jest.mock above) to exercise the Getty script hook.
+  let realSanitize: typeof import('./sanitize.js').sanitize;
+
+  beforeAll(async () => {
+    jest.resetModules();
+    jest.unmock('dompurify');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    ({ sanitize: realSanitize } = require('./sanitize'));
+  });
+
+  it('keeps Getty embed scripts when a caller opts in via ADD_TAGS', () => {
+    const html =
+      "<a class='gie-single' href='https://www.gettyimages.com/detail/123'>Embed from Getty Images</a>" +
+      '<script>window.gie=window.gie||function(c){(window.gie.q=window.gie.q||[]).push(c)};</script>' +
+      '<script src="https://embed-cdn.gettyimages.com/widgets.js" async charset="utf-8"></script>';
+
+    const result = realSanitize(html, { ADD_TAGS: ['script'], ADD_ATTR: ['async', 'charset'] });
+
+    expect(result).toContain('window.gie');
+    expect(result).toContain('embed-cdn.gettyimages.com/widgets.js');
+  });
+
+  it('strips scripts that are not Getty embeds even when a caller opts in via ADD_TAGS', () => {
+    const html = '<script>alert("xss")</script>';
+    const result = realSanitize(html, { ADD_TAGS: ['script'] });
+    expect(result).not.toContain('script');
+    expect(result).not.toContain('alert');
+  });
+
+  it('strips scripts by default when a caller does not opt in via ADD_TAGS', () => {
+    const html = '<script src="https://embed-cdn.gettyimages.com/widgets.js"></script><p>Text</p>';
+    const result = realSanitize(html);
+    expect(result).not.toContain('script');
+    expect(result).toContain('Text');
+  });
+});

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -1,5 +1,22 @@
 import DOMPurify from 'dompurify';
 
+// Getty's embed widget ships as a `gie-single` link plus two <script> tags. DOMPurify
+// strips scripts by default; callers that opt in via ADD_TAGS: ['script'] still only
+// get scripts through this hook when they're Getty's own loader/bootstrap.
+const GETTY_SCRIPT_SRC = /^https:\/\/embed-cdn\.gettyimages\.com\//i;
+const GETTY_BOOTSTRAP_SCRIPT = /window\.gie\b/;
+
+if (typeof window !== 'undefined' && typeof DOMPurify.addHook === 'function') {
+  DOMPurify.addHook('uponSanitizeElement', (node) => {
+    if (node.nodeName?.toLowerCase() !== 'script') return;
+    const element = node as Element;
+    const src = element.getAttribute?.('src') ?? '';
+    const inline = element.textContent ?? '';
+    const isGettyScript = GETTY_SCRIPT_SRC.test(src) || GETTY_BOOTSTRAP_SCRIPT.test(inline);
+    if (!isGettyScript) element.remove?.();
+  });
+}
+
 export function sanitize(html: string, config?: DOMPurify.Config): string {
   if (typeof window === 'undefined') return html;
   return DOMPurify.sanitize(html, config) as string;


### PR DESCRIPTION
## Summary
- Getty's embed widget (an `<a>` link plus two `<script>` tags) was being reduced to just the "Embed from Getty Images" link because DOMPurify strips `<script>` tags by default (e.g. https://www.worldofwinfield.co.uk/world-cup-surrender).
- `lib/sanitize.ts` now has a DOMPurify hook that keeps `<script>` tags only when they're Getty's own loader (`embed-cdn.gettyimages.com`) or bootstrap (`window.gie`), and only for callers that opt in via `ADD_TAGS: ['script']`. All other call sites (previews, titles, search results) are unaffected and still strip scripts.
- `components/post-body.tsx` opts in for full post rendering, and re-creates any `<script>` tags after mount, since `dangerouslySetInnerHTML` doesn't execute injected scripts natively.

## Test plan
- [x] `yarn jest --coverage=false` — 53 suites / 322 tests pass
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn lint` — clean
- [ ] Verify on a deployed preview that https://www.worldofwinfield.co.uk/world-cup-surrender renders the actual Getty photos instead of the bare link

🤖 Generated with [Claude Code](https://claude.com/claude-code)