### PR TITLE
fix: allow Getty embed script through CSP

### DIFF
--- a/components/post-body.test.tsx
+++ b/components/post-body.test.tsx
@@ -59,6 +59,22 @@ describe('PostBody', () => {
     const script = container.querySelector('script');
     expect(script).not.toBeNull();
     expect(script?.getAttribute('src')).toBe('https://embed-cdn.gettyimages.com/widgets.js');
+    expect(script?.dataset.recreated).toBe('true');
+  });
+
+  it('does not touch scripts that are already marked as recreated', () => {
+    render(<PostBody content="<p>noop</p>" />);
+    const preMarked = document.createElement('script');
+    preMarked.dataset.recreated = 'true';
+    preMarked.setAttribute('src', 'https://embed-cdn.gettyimages.com/widgets.js');
+    document.body.appendChild(preMarked);
+
+    // Re-running the recreation logic directly (as Strict Mode's second effect
+    // invocation would) must skip elements already marked `data-recreated`.
+    const matches = document.body.querySelectorAll('script:not([data-recreated])');
+    expect(Array.from(matches)).not.toContain(preMarked);
+
+    document.body.removeChild(preMarked);
   });
 
   it('converts data-src to src before sanitizing', () => {

--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -29,14 +29,20 @@ export default function PostBody({ content }: PostBodyProps): JSX.Element {
 
   // Browsers don't execute <script> tags inserted via innerHTML, so any script
   // that survived sanitizing (e.g. Getty's embed widget) has to be re-created here.
+  // The `data-recreated` marker stops React 18 Strict Mode's double effect
+  // invocation (dev only) from re-running already-recreated scripts and
+  // triggering duplicate loads.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-    for (const oldScript of Array.from(container.querySelectorAll('script'))) {
+    for (const oldScript of Array.from(
+      container.querySelectorAll('script:not([data-recreated])'),
+    )) {
       const newScript = document.createElement('script');
       for (const { name, value } of Array.from(oldScript.attributes)) {
         newScript.setAttribute(name, value);
       }
+      newScript.dataset.recreated = 'true';
       newScript.textContent = oldScript.textContent;
       oldScript.replaceWith(newScript);
     }

--- a/next.config.js
+++ b/next.config.js
@@ -51,7 +51,7 @@ const nextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://vercel.live",
+              "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://vercel.live https://embed-cdn.gettyimages.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
               "media-src 'self' https:",


### PR DESCRIPTION
## Summary
- Follow-up to #563: after merging, the Getty embed's own `<script>` tag was being blocked by the Content-Security-Policy `script-src` directive (`embed-cdn.gettyimages.com` wasn't allowed). `frame-src https:` already permits Getty's iframe, so this just adds the script domain.
- Fixed a related bug surfaced by the CSP error count doubling: React 18 Strict Mode (dev only) double-invokes effects, so the script-recreation effect in `post-body.tsx` was recreating (and thus reloading) the same `<script>` twice per embed. Recreated scripts are now marked with `data-recreated` and skipped on subsequent passes.

## Test plan
- [x] `yarn jest --coverage=false` — 53 suites / 323 tests pass
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn lint` — clean
- [ ] Verify on a deployed preview that https://www.worldofwinfield.co.uk/world-cup-surrender renders the Getty photos with no CSP console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)