### PR TITLE
fix: og:url pointed at literal /[slug] causing Facebook 404s

### DIFF
--- a/components/meta.test.tsx
+++ b/components/meta.test.tsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import Meta from './meta';
 
 jest.mock('next/router', () => ({
-  useRouter: () => ({ pathname: '/test-path' }),
+  useRouter: () => ({ asPath: '/test-path' }),
 }));
 
 // Capture the React elements passed to Head so we can inspect them directly.

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -28,7 +28,7 @@ export default function Meta({
 
   const { opengraphImage, opengraphTitle, opengraphDescription, opengraphSiteName, metaKeywords } =
     seo || {};
-  const canonicalUrl = `${siteAddress}${router.pathname}`;
+  const canonicalUrl = `${siteAddress}${router.asPath}`;
 
   return (
     <Head>


### PR DESCRIPTION
## Summary
- Blog post pages' `og:url` and canonical link were built from `router.pathname`, which for the dynamic `[slug]` route returns the literal file-route pattern `/[slug]` rather than the resolved URL.
- Facebook's link scraper uses `og:url` as the canonical link when a URL is shared, so it followed the broken literal `/[slug]` URL and returned a 404. Threads/Bluesky don't do this, which is why the same posts worked fine there.
- Switched to `router.asPath`, which resolves to the real path (e.g. `/james-went-to-kyoto-hiroshima-japan`), matching the pattern already used elsewhere in the codebase (e.g. the `favourite-*` page share bars).

## Test plan
- [x] `yarn jest components/meta.test.tsx` passes with updated mock
- [ ] After deploy, re-scrape an affected post URL via Facebook's Sharing Debugger (https://developers.facebook.com/tools/debug/) to clear the previously cached broken `og:url`