### PR TITLE
Fix CSP blocking WebSocket connection to Railway realtime server

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,7 +56,7 @@ const nextConfig = {
               "img-src 'self' data: https:",
               "media-src 'self' https:",
               "font-src 'self'",
-              "connect-src 'self' https://*.google-analytics.com https://vercel.live https://sheets.googleapis.com",
+              "connect-src 'self' https://*.google-analytics.com https://vercel.live https://sheets.googleapis.com wss://worldofwinfield-nextjs-production.up.railway.app",
               'frame-src https:',
               "frame-ancestors 'none'",
             ].join('; '),


### PR DESCRIPTION
## Summary
- The stocks page (`pages/stocks.tsx`) opens a WebSocket to `wss://worldofwinfield-nextjs-production.up.railway.app` for live price updates.
- The `connect-src` directive in the Content Security Policy (`next.config.js`) didn't allow this origin, so the browser blocked the connection with:
  > Connecting to 'wss://worldofwinfield-nextjs-production.up.railway.app/' violates the following Content Security Policy directive: "connect-src 'self' https://*.google-analytics.com https://vercel.live https://sheets.googleapis.com". The action has been blocked.
- Added `wss://worldofwinfield-nextjs-production.up.railway.app` to `connect-src` so the WebSocket can connect.

## Test plan
- [ ] Deploy/preview and confirm the stocks page connects via WebSocket without a CSP violation in the browser console
- [ ] Confirm other CSP-governed functionality (analytics, Vercel live, Google Sheets API) still works as expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdL2w7VHBBH2wV8uuYD9xi)_