### PR TITLE
tests: add coverage for block-colours and untested api functions

### DIFF
--- a/lib/api.test.ts
+++ b/lib/api.test.ts
@@ -1,8 +1,11 @@
 import {
+  filterPostsByTag,
   getAdjacentPosts,
+  getAllTags,
   getArchivePost,
   getPostsByDate,
   getRelatedPosts,
+  getTotalPostCount,
   searchBlogPosts,
 } from './api';
 
@@ -175,5 +178,59 @@ describe('getArchivePost', () => {
 
     const result = await getArchivePost();
     expect(result).toBeNull();
+  });
+});
+
+describe('filterPostsByTag', () => {
+  it('sends the tag as a GraphQL variable and returns the nodes array', async () => {
+    const nodes = [
+      { id: '1', title: 'Tagged Post', slug: 'tagged', date: '2024-01-01', excerpt: '' },
+    ];
+    mockFetch.mockResolvedValue(gqlSuccess({ posts: { nodes } }));
+
+    const result = await filterPostsByTag('travel');
+
+    expect(result).toEqual(nodes);
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.variables).toEqual({ tag: 'travel' });
+  });
+});
+
+describe('getAllTags', () => {
+  it('filters out tags with no count and returns the rest sorted by count descending', async () => {
+    const nodes = [
+      { name: 'food', slug: 'food', count: 5 },
+      { name: 'travel', slug: 'travel', count: 20 },
+      { name: 'unused', slug: 'unused', count: null },
+      { name: 'music', slug: 'music', count: 12 },
+    ];
+    mockFetch.mockResolvedValue(gqlSuccess({ tags: { nodes } }));
+
+    const result = await getAllTags();
+
+    expect(result).toEqual([
+      { name: 'travel', slug: 'travel', count: 20 },
+      { name: 'music', slug: 'music', count: 12 },
+      { name: 'food', slug: 'food', count: 5 },
+    ]);
+    expect(result.find((t) => t.name === 'unused')).toBeUndefined();
+  });
+});
+
+describe('getTotalPostCount', () => {
+  it('returns the integer parsed from the X-WP-Total response header', async () => {
+    mockFetch.mockResolvedValueOnce({
+      headers: { get: (h: string) => (h === 'X-WP-Total' ? '42' : null) },
+    });
+
+    const count = await getTotalPostCount();
+    expect(count).toBe(42);
+  });
+
+  it('returns 0 when the fetch request throws a network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const count = await getTotalPostCount();
+    expect(count).toBe(0);
   });
 });

--- a/lib/block-colours.test.ts
+++ b/lib/block-colours.test.ts
@@ -1,0 +1,42 @@
+import { blockColours, getColourFromTitle, getColoursFromTitle } from './block-colours';
+
+jest.mock('../pages/_app', () => ({
+  colours: {
+    purple: '#8884FF',
+    pink: '#D90368',
+    burgandy: '#820263',
+    dark: '#291720',
+    green: '#04A777',
+    white: '#FFFFFF',
+    blueish: '#547AA5',
+    azure: '#3185FC',
+  },
+}));
+
+describe('getColourFromTitle', () => {
+  it('returns a string that exists in blockColours', () => {
+    const colour = getColourFromTitle('Hello World');
+    expect(blockColours).toContain(colour);
+  });
+
+  it('is deterministic — same title always produces the same colour', () => {
+    const title = 'My Consistent Blog Post Title';
+    expect(getColourFromTitle(title)).toBe(getColourFromTitle(title));
+  });
+});
+
+describe('getColoursFromTitle', () => {
+  it('returns colour1 and colour2 that are both members of blockColours', () => {
+    const { colour1, colour2 } = getColoursFromTitle('Test Title');
+    expect(blockColours).toContain(colour1);
+    expect(blockColours).toContain(colour2);
+  });
+
+  it('colour1 and colour2 are always distinct from each other', () => {
+    const titles = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta', 'Theta'];
+    for (const title of titles) {
+      const { colour1, colour2 } = getColoursFromTitle(title);
+      expect(colour1).not.toBe(colour2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds 8 new unit tests targeting two previously uncovered areas of `lib/`:

- **`lib/block-colours.test.ts`** (new file): `lib/block-colours.ts` was the only lib file with zero test coverage. Four tests cover the public API — `getColourFromTitle` (determinism, valid output) and `getColoursFromTitle` (both colours are in the palette, the two colours are always distinct from each other). The `pages/_app` import is mocked so the test stays fast and doesn't pull in Emotion/Next.js rendering.

- **`lib/api.test.ts`** (extended): Four new describe blocks cover three previously untested functions:
  - `filterPostsByTag` — verifies the tag variable is forwarded correctly and the nodes array is returned
  - `getAllTags` — verifies tags with a `null` count are filtered out and the result is sorted by count descending
  - `getTotalPostCount` — verifies the `X-WP-Total` REST header is parsed to an integer, and that a network error falls back to `0`

All 355 tests pass; `yarn lint` exits cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLHPsVEDQmCVHvS7DtEbnp)_