### PR TITLE
fix(a11y): remove focusable button role from aria-hidden intro blocks

### DIFF
--- a/components/intro.tsx
+++ b/components/intro.tsx
@@ -54,9 +54,6 @@ export default function Intro({ jamesImages }: IntroProps): JSX.Element {
               key={index}
               color={blockColours[getColour(index)]}
               data-index={index}
-              role="button"
-              tabIndex={0}
-              aria-label={`Reveal photo for letter ${letter === ' ' ? 'space' : letter}`}
               onMouseEnter={handleMouseEnter}
               onMouseLeave={handleMouseLeave}>
               <FlipContainer>


### PR DESCRIPTION
## Summary

The `axe` accessibility check was failing on PR #568 (and would fail on any PR, since it runs against `main`'s homepage) with:

```
Violation of "aria-hidden-focus" with 1 occurrences!
Ensure aria-hidden elements are not focusable nor contain focusable elements.
Correct invalid elements at: .css-cd7i09
```

`components/intro.tsx`'s `GridContainer` (the decorative letter-block grid on the homepage) is marked `aria-hidden="true"`, but its `Block` children had `role="button"` and `tabIndex={0}`, making them keyboard-focusable even though they're hidden from assistive technology — exactly the condition axe-core's `aria-hidden-focus` rule flags.

The blocks only ever respond to `onMouseEnter`/`onMouseLeave` (there's no keyboard handler), and the homepage already exposes an accessible `HiddenHeading` with the site name, so the button semantics on the blocks were serving no purpose. Removed `role="button"`, `tabIndex={0}`, and the now-unused `aria-label`.

## Test plan

- [x] `yarn test components/intro.test.tsx` — all 3 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] Re-run the `axe` CI job on this PR to confirm the violation is resolved

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuxwQBvcRpqAeVatmhVp9p)_