### PR TITLE
Add global cross-content search across blog, favourites, and wish lists

### DIFF
--- a/components/search-bar.test.tsx
+++ b/components/search-bar.test.tsx
@@ -106,4 +106,25 @@ describe('SearchBar', () => {
       expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
     });
   });
+
+  it('queries a custom endpoint when one is provided', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ posts: [] }) });
+    render(<SearchBar onSearch={() => {}} endpoint="/api/global-search" />);
+
+    const input = screen.getByPlaceholderText('Search blog...');
+    fireEvent.change(input, { target: { value: 'barcelona' } });
+
+    const form = input.closest('form')!;
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/global-search?q=barcelona');
+    });
+  });
+
+  it('renders a custom label and placeholder when provided', () => {
+    render(<SearchBar onSearch={() => {}} label="Search everything" placeholder="Search all..." />);
+    expect(screen.getByText('Search everything')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search all...')).toBeInTheDocument();
+  });
 });

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -4,7 +4,12 @@ import type { SearchBarProps, SearchResult } from '../lib/types';
 import { colours } from '../pages/_app';
 import { StyledButton, StyledInput } from './core-components';
 
-const SearchBar = ({ onSearch }: SearchBarProps): JSX.Element => {
+const SearchBar = <T = SearchResult[]>({
+  onSearch,
+  endpoint = '/api/search',
+  label = 'Search blog',
+  placeholder = 'Search blog...',
+}: SearchBarProps<T>): JSX.Element => {
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -16,19 +21,19 @@ const SearchBar = ({ onSearch }: SearchBarProps): JSX.Element => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
     setLoading(true);
-    const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
-    const searchResults = (await res.json()) as SearchResult[];
+    const res = await fetch(`${endpoint}?q=${encodeURIComponent(query)}`);
+    const searchResults = (await res.json()) as T;
     setLoading(false);
     onSearch(searchResults);
   };
 
   return (
     <StyledForm onSubmit={handleSubmit}>
-      <label htmlFor="blog-search-input">Search blog</label>
+      <label htmlFor="blog-search-input">{label}</label>
       <StyledInput
         id="blog-search-input"
         type="text"
-        placeholder="Search blog..."
+        placeholder={placeholder}
         value={query}
         onChange={handleChange}
       />

--- a/components/search-results.test.tsx
+++ b/components/search-results.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
+import type { GlobalSearchResults } from '../lib/types';
 import SearchResults, { formatDate } from './search-results';
 
 jest.mock('../pages/_app', () => ({
@@ -15,6 +16,8 @@ jest.mock('../pages/_app', () => ({
     azure: '#3185FC',
   },
 }));
+
+const emptyResults: GlobalSearchResults = { posts: [] };
 
 describe('formatDate', () => {
   it('adds "st" suffix for the 1st', () => {
@@ -76,32 +79,64 @@ describe('SearchResults', () => {
     expect(container.firstChild).toBeEmptyDOMElement();
   });
 
-  it('renders "No results found." when searchResults is an empty array', () => {
-    render(<SearchResults searchResults={[]} />);
+  it('renders "No results found." when searchResults has no items in any category', () => {
+    render(<SearchResults searchResults={emptyResults} />);
     expect(screen.getByText('No results found.')).toBeInTheDocument();
   });
 
-  it('renders a list of results when searchResults has items', () => {
-    const results = [
-      { slug: 'post-one', title: 'Post One', date: '2023-01-15' },
-      { slug: 'post-two', title: 'Post Two', date: '2023-06-20' },
-    ];
+  it('renders a list of blog post results when posts are present', () => {
+    const results: GlobalSearchResults = {
+      posts: [
+        { slug: 'post-one', title: 'Post One', date: '2023-01-15' },
+        { slug: 'post-two', title: 'Post Two', date: '2023-06-20' },
+      ],
+    };
     render(<SearchResults searchResults={results} />);
     expect(screen.getByText('2 results')).toBeInTheDocument();
+    expect(screen.getByText('Blog posts')).toBeInTheDocument();
     expect(screen.getByText('Post One')).toBeInTheDocument();
     expect(screen.getByText('Post Two')).toBeInTheDocument();
   });
 
-  it('renders a link to each result using its slug', () => {
-    const results = [{ slug: 'my-post', title: 'My Post', date: '2023-01-15' }];
+  it('renders a link to each blog post result using its slug', () => {
+    const results: GlobalSearchResults = {
+      posts: [{ slug: 'my-post', title: 'My Post', date: '2023-01-15' }],
+    };
     render(<SearchResults searchResults={results} />);
     const link = screen.getByText('My Post').closest('a');
     expect(link).toHaveAttribute('href', '/my-post');
   });
 
   it('does not render "No results found." when results exist', () => {
-    const results = [{ slug: 'post-one', title: 'Post One', date: '2023-01-15' }];
+    const results: GlobalSearchResults = {
+      posts: [{ slug: 'post-one', title: 'Post One', date: '2023-01-15' }],
+    };
     render(<SearchResults searchResults={results} />);
     expect(screen.queryByText('No results found.')).not.toBeInTheDocument();
+  });
+
+  it('renders grouped results from favourites and wish list categories', () => {
+    const results: GlobalSearchResults = {
+      posts: [],
+      books: [{ title: 'Norwegian Wood', subtitle: 'Haruki Murakami', url: '/favourite-books' }],
+      cities: [{ title: 'Barcelona', url: '/favourite-cities' }],
+    };
+    render(<SearchResults searchResults={results} />);
+    expect(screen.getByText('2 results')).toBeInTheDocument();
+    expect(screen.getByText('Favourite books')).toBeInTheDocument();
+    expect(screen.getByText('Norwegian Wood')).toBeInTheDocument();
+    expect(screen.getByText('— Haruki Murakami')).toBeInTheDocument();
+    expect(screen.getByText('Favourite cities visited')).toBeInTheDocument();
+    const link = screen.getByText('Barcelona').closest('a');
+    expect(link).toHaveAttribute('href', '/favourite-cities');
+  });
+
+  it('does not render a section for a category with no matching items', () => {
+    const results: GlobalSearchResults = {
+      posts: [],
+      books: [{ title: 'Norwegian Wood', url: '/favourite-books' }],
+    };
+    render(<SearchResults searchResults={results} />);
+    expect(screen.queryByText('Favourite movies')).not.toBeInTheDocument();
   });
 });

--- a/components/search-results.tsx
+++ b/components/search-results.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import React, { type JSX } from 'react';
 import { sanitize } from '../lib/sanitize';
+import { searchableSheets } from '../lib/search-sheets';
 import type { SearchResultsProps } from '../lib/types';
 import { colours } from '../pages/_app';
 
@@ -34,52 +35,82 @@ const stripReadMoreParagraph = (excerpt: string): string => {
 };
 
 const SearchResults = ({ searchResults }: SearchResultsProps): JSX.Element => {
+  if (searchResults === null) {
+    return <SearchResultsContainer aria-live="polite" aria-atomic="false" role="status" />;
+  }
+
+  const categoryEntries = searchableSheets
+    .map((sheet) => ({ sheet, items: searchResults[sheet.key] ?? [] }))
+    .filter((entry) => entry.items.length > 0);
+
+  const totalCount =
+    searchResults.posts.length +
+    categoryEntries.reduce((sum, entry) => sum + entry.items.length, 0);
+
   return (
     <SearchResultsContainer aria-live="polite" aria-atomic="false" role="status">
-      {searchResults !== null && searchResults.length === 0 && (
-        <p className="center">No results found.</p>
-      )}
-      {(searchResults?.length ?? 0) > 0 && (
+      {totalCount === 0 && <p className="center">No results found.</p>}
+      {totalCount > 0 && (
         <>
           <ResultCount>
-            {searchResults!.length} result{searchResults!.length !== 1 ? 's' : ''}
+            {totalCount} result{totalCount !== 1 ? 's' : ''}
           </ResultCount>
-          {searchResults!.map((post) => (
-            <SearchCard key={post.slug}>
-              {post.featuredImage?.node.sourceUrl && (
-                <SearchCardImageWrapper>
-                  <Link href={`/${post.slug}`} aria-label={post.title}>
-                    <Image
-                      alt=""
-                      src={post.featuredImage.node.sourceUrl}
-                      sizes="(max-width: 768px) 100vw, 240px"
-                      quality={75}
-                      fill
-                    />
-                  </Link>
-                </SearchCardImageWrapper>
-              )}
-              <SearchCardContent>
-                <SearchCardTitle>
-                  <Link href={`/${post.slug}`}>{post.title}</Link>
-                </SearchCardTitle>
-                <SearchCardDate>{formatDate(post.date)}</SearchCardDate>
-                {post.excerpt && (
-                  <SearchCardExcerpt
-                    dangerouslySetInnerHTML={{
-                      __html: sanitize(stripReadMoreParagraph(post.excerpt)),
-                    }}
-                  />
-                )}
-                <ContinueReadingLink
-                  href={`/${post.slug}`}
-                  colour={getColourFromTitle(post.title)}
-                  textcolour={getTextColour(getColourFromTitle(post.title))}
-                  aria-label={`Continue reading about ${post.title}`}>
-                  Continue reading
-                </ContinueReadingLink>
-              </SearchCardContent>
-            </SearchCard>
+          {searchResults.posts.length > 0 && (
+            <ResultSection>
+              <SectionTitle>Blog posts</SectionTitle>
+              {searchResults.posts.map((post) => (
+                <SearchCard key={post.slug}>
+                  {post.featuredImage?.node.sourceUrl && (
+                    <SearchCardImageWrapper>
+                      <Link href={`/${post.slug}`} aria-label={post.title}>
+                        <Image
+                          alt=""
+                          src={post.featuredImage.node.sourceUrl}
+                          sizes="(max-width: 768px) 100vw, 240px"
+                          quality={75}
+                          fill
+                        />
+                      </Link>
+                    </SearchCardImageWrapper>
+                  )}
+                  <SearchCardContent>
+                    <SearchCardTitle>
+                      <Link href={`/${post.slug}`}>{post.title}</Link>
+                    </SearchCardTitle>
+                    <SearchCardDate>{formatDate(post.date)}</SearchCardDate>
+                    {post.excerpt && (
+                      <SearchCardExcerpt
+                        dangerouslySetInnerHTML={{
+                          __html: sanitize(stripReadMoreParagraph(post.excerpt)),
+                        }}
+                      />
+                    )}
+                    <ContinueReadingLink
+                      href={`/${post.slug}`}
+                      colour={getColourFromTitle(post.title)}
+                      textcolour={getTextColour(getColourFromTitle(post.title))}
+                      aria-label={`Continue reading about ${post.title}`}>
+                      Continue reading
+                    </ContinueReadingLink>
+                  </SearchCardContent>
+                </SearchCard>
+              ))}
+            </ResultSection>
+          )}
+          {categoryEntries.map(({ sheet, items }) => (
+            <ResultSection key={sheet.key}>
+              <SectionTitle>{sheet.label}</SectionTitle>
+              <CategoryList>
+                {items.map((item, index) => (
+                  <li key={`${sheet.key}-${index}`}>
+                    <Link href={sheet.path}>{item.title}</Link>
+                    {item.subtitle && (
+                      <CategoryItemSubtitle> — {item.subtitle}</CategoryItemSubtitle>
+                    )}
+                  </li>
+                ))}
+              </CategoryList>
+            </ResultSection>
           ))}
         </>
       )}
@@ -141,6 +172,46 @@ const ResultCount = styled.p`
   color: #666;
   margin-bottom: 1.5rem;
   text-align: center;
+`;
+
+const ResultSection = styled.section`
+  margin-bottom: 2rem;
+`;
+
+const SectionTitle = styled.h2`
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5rem;
+`;
+
+const CategoryList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #eee;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  a {
+    color: inherit;
+    font-weight: bold;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const CategoryItemSubtitle = styled.span`
+  color: #666;
 `;
 
 const SearchCardImageWrapper = styled.div`

--- a/lib/search-sheets.ts
+++ b/lib/search-sheets.ts
@@ -1,0 +1,104 @@
+import type { GlobalSearchCategoryKey } from './types';
+
+export type SearchableSheet = {
+  key: GlobalSearchCategoryKey;
+  label: string;
+  sheetId: string;
+  path: string;
+  titleColumn: string;
+  subtitleColumn?: string;
+};
+
+export const searchableSheets: SearchableSheet[] = [
+  {
+    key: 'books',
+    label: 'Favourite books',
+    sheetId: '1G-QrN1NDpKAr12VyIi50Nod8_g-YOSGP3bovCXxDHlY',
+    path: '/favourite-books',
+    titleColumn: 'Title',
+    subtitleColumn: 'Author',
+  },
+  {
+    key: 'movies',
+    label: 'Favourite movies',
+    sheetId: '1q3LFzLYqK0tLWHjvHYxFE1IIF-FrOJuqJ6XBIQIEl6U',
+    path: '/favourite-movies',
+    titleColumn: 'Name',
+    subtitleColumn: 'Language',
+  },
+  {
+    key: 'restaurants',
+    label: 'Favourite restaurants',
+    sheetId: '1J1znKQxeNR3Y6Q1mEPzZyMfCAGK4FQyxasoCQx35NVQ',
+    path: '/favourite-restaurants',
+    titleColumn: 'Name',
+  },
+  {
+    key: 'cities',
+    label: 'Favourite cities visited',
+    sheetId: '1WBfOTfhC70AygxrTcIIgvigzlvOD65WfI9Ysrd3aF5o',
+    path: '/favourite-cities',
+    titleColumn: 'Name',
+  },
+  {
+    key: 'countries',
+    label: 'Favourite countries visited',
+    sheetId: '1zyzuLzWY0S6mUp-FVjcIa3QFAENcU94WVD9ZF0JWERY',
+    path: '/favourite-countries',
+    titleColumn: 'Name',
+  },
+  {
+    key: 'tracks',
+    label: 'Favourite tracks',
+    sheetId: '1ifEAiSgIMKrtTJ6fSHNGmQ-kMzR_MyAa-PjvBWOsBRA',
+    path: '/favourite-tracks',
+    titleColumn: 'Artist/Track Name',
+    subtitleColumn: 'Label',
+  },
+  {
+    key: 'djs',
+    label: 'Favourite DJs',
+    sheetId: '1_zpDBFlpW2ZWTVsXQHoW6Y4FbGw8Vi53nMYpZiOypbg',
+    path: '/favourite-djs',
+    titleColumn: 'Name',
+  },
+  {
+    key: 'holidayWishList',
+    label: 'Holiday wish list',
+    sheetId: '1GX6KF20f3Nrb3m8T9th7UIV_uuePj4Ivlc_yLgo-4Bo',
+    path: '/holiday-wish-list',
+    titleColumn: 'Name',
+    subtitleColumn: 'Country',
+  },
+  {
+    key: 'restaurantWishList',
+    label: 'Restaurant wish list',
+    sheetId: '13gz7lPQ61f_WKQ_xio_QBlUcFB9Dl0yVBynwEadVO_4',
+    path: '/restaurant-wish-list',
+    titleColumn: 'Restaurant Name',
+    subtitleColumn: 'Cuisine',
+  },
+  {
+    key: 'articles',
+    label: 'Favourite articles',
+    sheetId: '1R928oTM4hiTFXZ6Ww9-2pMKLAWy2Wjf3Z9xrXC6GTa0',
+    path: '/favourite-articles',
+    titleColumn: 'About',
+  },
+  {
+    key: 'beers',
+    label: 'Favourite beers',
+    sheetId: '1pNNIw849xWrQHtDptwInGs6Un0AZh-fgXUssC3XIrHM',
+    path: '/favourite-beers',
+    titleColumn: 'Beer Name',
+    subtitleColumn: 'Brewery',
+  },
+  {
+    key: 'cheese',
+    label: 'Favourite cheese',
+    sheetId: '1UDjT7_Q5rBPQasn4o2qxUOsEcElEI67nl-ep9YTLc-E',
+    path: '/favourite-cheese',
+    titleColumn: 'Name',
+    subtitleColumn: 'Bought From',
+  },
+];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -499,12 +499,39 @@ export type SearchResult = {
   };
 };
 
-export type SearchBarProps = {
-  onSearch: (results: SearchResult[]) => void;
+export type GlobalSearchItem = {
+  title: string;
+  subtitle?: string;
+  url: string;
+};
+
+export type GlobalSearchCategoryKey =
+  | 'books'
+  | 'movies'
+  | 'restaurants'
+  | 'cities'
+  | 'countries'
+  | 'tracks'
+  | 'djs'
+  | 'holidayWishList'
+  | 'restaurantWishList'
+  | 'articles'
+  | 'beers'
+  | 'cheese';
+
+export type GlobalSearchResults = {
+  posts: SearchResult[];
+} & Partial<Record<GlobalSearchCategoryKey, GlobalSearchItem[]>>;
+
+export type SearchBarProps<T = SearchResult[]> = {
+  onSearch: (results: T) => void;
+  endpoint?: string;
+  label?: string;
+  placeholder?: string;
 };
 
 export type SearchResultsProps = {
-  searchResults: SearchResult[] | null;
+  searchResults: GlobalSearchResults | null;
 };
 
 export type ArchivePageProps = {

--- a/pages/api/global-search.test.ts
+++ b/pages/api/global-search.test.ts
@@ -1,0 +1,86 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { searchBlogPosts } from '../../lib/api';
+import { searchableSheets } from '../../lib/search-sheets';
+import { fetchDataFromGoogleSheets } from '../../lib/sheets';
+import handler from './global-search';
+
+jest.mock('../../lib/api');
+jest.mock('../../lib/sheets');
+
+function createMockReq(overrides: Partial<NextApiRequest> = {}): NextApiRequest {
+  return { method: 'GET', query: {}, ...overrides } as NextApiRequest;
+}
+
+function createMockRes(): NextApiResponse {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as NextApiResponse;
+}
+
+describe('GET /api/global-search', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 405 for non-GET requests', async () => {
+    const req = createMockReq({ method: 'POST' });
+    const res = createMockRes();
+    await handler(req, res);
+    expect(res.status as jest.Mock).toHaveBeenCalledWith(405);
+    expect(res.json as jest.Mock).toHaveBeenCalledWith({ message: 'Method Not Allowed' });
+  });
+
+  it('returns blog posts and matching sheet rows grouped by category', async () => {
+    const mockPosts = [{ slug: 'barcelona-trip', title: 'Barcelona Trip', date: '2023-01-01' }];
+    (searchBlogPosts as jest.Mock).mockResolvedValue(mockPosts);
+    (fetchDataFromGoogleSheets as jest.Mock).mockImplementation(async (sheetId: string) => {
+      const booksSheet = searchableSheets.find((sheet) => sheet.key === 'books')!;
+      const citiesSheet = searchableSheets.find((sheet) => sheet.key === 'cities')!;
+      if (sheetId === booksSheet.sheetId) {
+        return [
+          ['Author', 'Title', 'Score', 'Year Read', 'Comments'],
+          ['Haruki Murakami', 'Norwegian Wood', '9', '2020', ''],
+          ['George Orwell', '1984', '10', '2019', ''],
+        ];
+      }
+      if (sheetId === citiesSheet.sheetId) {
+        return [['Name'], ['Barcelona'], ['Tokyo']];
+      }
+      return [];
+    });
+
+    const req = createMockReq({ query: { q: 'barcelona' } });
+    const res = createMockRes();
+    await handler(req, res);
+
+    expect(res.status as jest.Mock).toHaveBeenCalledWith(200);
+    const payload = (res.json as jest.Mock).mock.calls[0][0];
+    expect(payload.posts).toEqual(mockPosts);
+    expect(payload.cities).toEqual([
+      { title: 'Barcelona', subtitle: undefined, url: '/favourite-cities' },
+    ]);
+    expect(payload.books).toBeUndefined();
+  });
+
+  it('omits categories with no matching rows', async () => {
+    (searchBlogPosts as jest.Mock).mockResolvedValue([]);
+    (fetchDataFromGoogleSheets as jest.Mock).mockResolvedValue(null);
+
+    const req = createMockReq({ query: { q: 'nothing-matches-anything' } });
+    const res = createMockRes();
+    await handler(req, res);
+
+    const payload = (res.json as jest.Mock).mock.calls[0][0];
+    expect(payload).toEqual({ posts: [] });
+  });
+
+  it('passes an empty string when no query is provided', async () => {
+    (searchBlogPosts as jest.Mock).mockResolvedValue([]);
+    (fetchDataFromGoogleSheets as jest.Mock).mockResolvedValue(null);
+    const req = createMockReq({ query: {} });
+    const res = createMockRes();
+    await handler(req, res);
+    expect(searchBlogPosts).toHaveBeenCalledWith('');
+  });
+});

--- a/pages/api/global-search.ts
+++ b/pages/api/global-search.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { searchBlogPosts } from '../../lib/api';
+import { searchableSheets } from '../../lib/search-sheets';
+import { fetchDataFromGoogleSheets } from '../../lib/sheets';
+import type { GlobalSearchItem, GlobalSearchResults } from '../../lib/types';
+
+const searchSheet = async (
+  sheet: (typeof searchableSheets)[number],
+  searchTerm: string,
+): Promise<GlobalSearchItem[]> => {
+  const rows = await fetchDataFromGoogleSheets(sheet.sheetId);
+  if (!rows || rows.length < 2) return [];
+
+  const headerRow = rows[0];
+  const titleIndex = headerRow.indexOf(sheet.titleColumn);
+  const subtitleIndex = sheet.subtitleColumn ? headerRow.indexOf(sheet.subtitleColumn) : -1;
+  const lowerQuery = searchTerm.trim().toLowerCase();
+
+  return rows
+    .slice(1)
+    .filter((row) => row.some((cell) => (cell ?? '').toString().toLowerCase().includes(lowerQuery)))
+    .map((row) => ({
+      title: (titleIndex !== -1 ? row[titleIndex] : row[0]) || '(untitled)',
+      subtitle: subtitleIndex !== -1 ? row[subtitleIndex] : undefined,
+      url: sheet.path,
+    }));
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'GET') return res.status(405).json({ message: 'Method Not Allowed' });
+  const rawQ = req.query.q;
+  const searchTerm = (Array.isArray(rawQ) ? rawQ[0] : rawQ) ?? '';
+
+  const [posts, ...sheetResults] = await Promise.all([
+    searchBlogPosts(searchTerm),
+    ...searchableSheets.map((sheet) => searchSheet(sheet, searchTerm)),
+  ]);
+
+  const results: GlobalSearchResults = { posts };
+  searchableSheets.forEach((sheet, index) => {
+    const items = sheetResults[index];
+    if (items.length > 0) results[sheet.key] = items;
+  });
+
+  res.status(200).json(results);
+}

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -9,16 +9,16 @@ import MoreStories from '../components/more-stories';
 import SearchBar from '../components/search-bar';
 import SearchResults from '../components/search-results';
 import { getAllPostsForHome } from '../lib/api';
-import type { IndexPageProps, SearchResult } from '../lib/types';
+import type { GlobalSearchResults, IndexPageProps } from '../lib/types';
 
 export default function Index({ allPosts, preview }: IndexPageProps) {
-  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searchResults, setSearchResults] = useState<GlobalSearchResults | null>(null);
   const [posts, setPosts] = useState(allPosts.edges);
   const [hasNextPage, setHasNextPage] = useState(allPosts.pageInfo.hasNextPage);
   const [endCursor, setEndCursor] = useState(allPosts.pageInfo.endCursor);
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSearch = (results: SearchResult[]) => {
+  const handleSearch = (results: GlobalSearchResults) => {
     setSearchResults(results);
   };
 
@@ -73,7 +73,12 @@ export default function Index({ allPosts, preview }: IndexPageProps) {
         </Link>
         <RssLink href="/api/feed">Subscribe via RSS</RssLink>
       </BrowseTopicsBar>
-      <SearchBar onSearch={handleSearch} />
+      <SearchBar<GlobalSearchResults>
+        onSearch={handleSearch}
+        endpoint="/api/global-search"
+        label="Search everything"
+        placeholder="Search blog, favourites, wish lists..."
+      />
       <SearchResults searchResults={searchResults} />
     </Layout>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ import {
   getPostDisplayInfo,
   getRandomImage,
 } from '../lib/api';
-import type { IndexPageProps, SearchResult } from '../lib/types';
+import type { GlobalSearchResults, IndexPageProps } from '../lib/types';
 
 export default function Index({
   preview,
@@ -24,7 +24,7 @@ export default function Index({
   randomImageSet,
   archivePost,
 }: IndexPageProps) {
-  const [searchResults, setSearchResults] = useState<SearchResult[] | null>(null);
+  const [searchResults, setSearchResults] = useState<GlobalSearchResults | null>(null);
   const [randomImage, setRandomImage] = useState<
     | IndexPageProps['jamesImages']['edges'][0]['node']['featuredImage']
     | NonNullable<IndexPageProps['randomImageSet']['images']>[number]
@@ -40,7 +40,7 @@ export default function Index({
     }
   }, [randomImageSet]);
 
-  const handleSearch = (results: SearchResult[]) => {
+  const handleSearch = (results: GlobalSearchResults) => {
     setSearchResults(results);
   };
 
@@ -366,7 +366,12 @@ export default function Index({
           />
         ))}
       </HomepageBlocksContainer>
-      <SearchBar onSearch={handleSearch} />
+      <SearchBar<GlobalSearchResults>
+        onSearch={handleSearch}
+        endpoint="/api/global-search"
+        label="Search everything"
+        placeholder="Search blog, favourites, wish lists..."
+      />
       <SearchResults searchResults={searchResults} />
     </Layout>
   );


### PR DESCRIPTION
## Summary
- Adds a `/api/global-search` endpoint that searches WordPress blog posts (reusing `searchBlogPosts`) alongside all 12 favourites/wish-list Google Sheets in parallel, filtering rows client-side by query
- Extends `SearchResults` to render results grouped by section (blog posts, favourite books, favourite movies, etc.) instead of a flat list of blog posts
- Wires up the homepage and blog page search bars to use the new global endpoint via a new `endpoint`/`label`/`placeholder` prop on `SearchBar`
- Adds `lib/search-sheets.ts` as the single source of truth for which sheets are searchable, their display columns, and their page paths

Closes #544

## Test plan
- [x] `yarn lint` (tsc --noEmit + biome check) passes
- [x] `yarn jest` — full suite (355 tests) passes, including new/updated tests for `search-bar`, `search-results`, and `global-search` API route
- [ ] Manually verify search on `/` and `/blog` returns grouped results in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)