### PR TITLE
refactor: fetch favourites/wish-list data server-side (getStaticProps/ISR)

### DIFF
--- a/__tests__/favourites-results.test.tsx
+++ b/__tests__/favourites-results.test.tsx
@@ -1,15 +1,7 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
 import FavouriteResults from '../pages/favourites-results';
-
-jest.mock('../lib/sheets', () => ({
-  fetchDataFromGoogleSheets: jest.fn(),
-}));
-
-import { fetchDataFromGoogleSheets } from '../lib/sheets';
-
-const mockFetch = fetchDataFromGoogleSheets as jest.Mock;
 
 const sampleData = [
   ['Title', 'Author', 'Score'],
@@ -19,23 +11,16 @@ const sampleData = [
 ];
 
 describe('FavouriteResults search', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-    mockFetch.mockResolvedValue(sampleData);
-  });
+  it('shows all rows when the search box is empty', () => {
+    render(<FavouriteResults data={sampleData} />);
 
-  it('shows all rows when the search box is empty', async () => {
-    render(<FavouriteResults sheetId="sheet-1" />);
-
-    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+    expect(screen.getByText('Dune')).toBeInTheDocument();
     expect(screen.getByText('Neuromancer')).toBeInTheDocument();
     expect(screen.getByText('Foundation')).toBeInTheDocument();
   });
 
-  it('filters rows in real time as the user types, case-insensitively', async () => {
-    render(<FavouriteResults sheetId="sheet-1" />);
-
-    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+  it('filters rows in real time as the user types, case-insensitively', () => {
+    render(<FavouriteResults data={sampleData} />);
 
     const searchInput = screen.getByLabelText('Search:');
     fireEvent.change(searchInput, { target: { value: 'gibson' } });
@@ -45,10 +30,8 @@ describe('FavouriteResults search', () => {
     expect(screen.queryByText('Foundation')).not.toBeInTheDocument();
   });
 
-  it('matches substrings against any column, not just the first', async () => {
-    render(<FavouriteResults sheetId="sheet-1" />);
-
-    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+  it('matches substrings against any column, not just the first', () => {
+    render(<FavouriteResults data={sampleData} />);
 
     const searchInput = screen.getByLabelText('Search:');
     fireEvent.change(searchInput, { target: { value: 'asimov' } });
@@ -57,10 +40,8 @@ describe('FavouriteResults search', () => {
     expect(screen.queryByText('Dune')).not.toBeInTheDocument();
   });
 
-  it('shows an empty state when there are no matches', async () => {
-    render(<FavouriteResults sheetId="sheet-1" />);
-
-    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+  it('shows an empty state when there are no matches', () => {
+    render(<FavouriteResults data={sampleData} />);
 
     const searchInput = screen.getByLabelText('Search:');
     fireEvent.change(searchInput, { target: { value: 'no such book' } });
@@ -68,10 +49,8 @@ describe('FavouriteResults search', () => {
     expect(screen.getByText(/No results for/)).toBeInTheDocument();
   });
 
-  it('restores the full list when the search input is cleared', async () => {
-    render(<FavouriteResults sheetId="sheet-1" />);
-
-    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument());
+  it('restores the full list when the search input is cleared', () => {
+    render(<FavouriteResults data={sampleData} />);
 
     const searchInput = screen.getByLabelText('Search:');
     fireEvent.change(searchInput, { target: { value: 'gibson' } });
@@ -82,5 +61,11 @@ describe('FavouriteResults search', () => {
     expect(screen.getByText('Dune')).toBeInTheDocument();
     expect(screen.getByText('Neuromancer')).toBeInTheDocument();
     expect(screen.getByText('Foundation')).toBeInTheDocument();
+  });
+
+  it('renders nothing when data is null', () => {
+    render(<FavouriteResults data={null} />);
+
+    expect(screen.queryByText('Dune')).not.toBeInTheDocument();
   });
 });

--- a/pages/favourite-articles.tsx
+++ b/pages/favourite-articles.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1R928oTM4hiTFXZ6Ww9-2pMKLAWy2Wjf3Z9xrXC6GTa0';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Articles Read';
-  const sheetId = '1R928oTM4hiTFXZ6Ww9-2pMKLAWy2Wjf3Z9xrXC6GTa0';
   const seo = {
     opengraphTitle: 'Favourite Articles | World Of Winfield',
     opengraphDescription: "A curated list of James Winfield's favourite articles read.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-beers.tsx
+++ b/pages/favourite-beers.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1pNNIw849xWrQHtDptwInGs6Un0AZh-fgXUssC3XIrHM';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Beer';
-  const sheetId = '1pNNIw849xWrQHtDptwInGs6Un0AZh-fgXUssC3XIrHM';
   const seo = {
     opengraphTitle: 'Favourite Beers | World Of Winfield',
     opengraphDescription: "A ranked list of James Winfield's favourite beers.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-books.tsx
+++ b/pages/favourite-books.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1G-QrN1NDpKAr12VyIi50Nod8_g-YOSGP3bovCXxDHlY';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Books';
-  const sheetId = '1G-QrN1NDpKAr12VyIi50Nod8_g-YOSGP3bovCXxDHlY';
   const seo = {
     opengraphTitle: 'Favourite Books | World Of Winfield',
     opengraphDescription: "A ranked list of James Winfield's favourite books.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-cheese.tsx
+++ b/pages/favourite-cheese.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1UDjT7_Q5rBPQasn4o2qxUOsEcElEI67nl-ep9YTLc-E';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Cheese';
-  const sheetId = '1UDjT7_Q5rBPQasn4o2qxUOsEcElEI67nl-ep9YTLc-E';
   const seo = {
     opengraphTitle: 'Favourite Cheese | World Of Winfield',
     opengraphDescription: "A ranked list of James Winfield's favourite cheeses.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-cities.tsx
+++ b/pages/favourite-cities.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1WBfOTfhC70AygxrTcIIgvigzlvOD65WfI9Ysrd3aF5o';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Cities Visited';
-  const sheetId = '1WBfOTfhC70AygxrTcIIgvigzlvOD65WfI9Ysrd3aF5o';
   const seo = {
     opengraphTitle: 'Favourite Cities Visited | World Of Winfield',
     opengraphDescription: "A ranked list of James Winfield's favourite cities visited.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-countries.tsx
+++ b/pages/favourite-countries.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1zyzuLzWY0S6mUp-FVjcIa3QFAENcU94WVD9ZF0JWERY';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Countries Visited';
-  const sheetId = '1zyzuLzWY0S6mUp-FVjcIa3QFAENcU94WVD9ZF0JWERY';
   const seo = {
     opengraphTitle: 'Favourite Countries Visited | World Of Winfield',
     opengraphDescription: "A ranked list of James Winfield's favourite countries visited.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-djs.tsx
+++ b/pages/favourite-djs.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1_zpDBFlpW2ZWTVsXQHoW6Y4FbGw8Vi53nMYpZiOypbg';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite DJs';
-  const sheetId = '1_zpDBFlpW2ZWTVsXQHoW6Y4FbGw8Vi53nMYpZiOypbg';
   const seo = {
     opengraphTitle: 'Favourite DJs | World Of Winfield',
     opengraphDescription: "A ranked list of James Winfield's favourite DJs.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-movies.tsx
+++ b/pages/favourite-movies.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1q3LFzLYqK0tLWHjvHYxFE1IIF-FrOJuqJ6XBIQIEl6U';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Movies';
-  const sheetId = '1q3LFzLYqK0tLWHjvHYxFE1IIF-FrOJuqJ6XBIQIEl6U';
   const seo = {
     opengraphTitle: 'Favourite Movies | World Of Winfield',
     opengraphDescription: "A ranked list of James Winfield's favourite movies.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-restaurants.tsx
+++ b/pages/favourite-restaurants.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
@@ -6,10 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
-export default function FavouritesPage() {
+
+const sheetId = '1J1znKQxeNR3Y6Q1mEPzZyMfCAGK4FQyxasoCQx35NVQ';
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Restaurants';
-  const sheetId = '1J1znKQxeNR3Y6Q1mEPzZyMfCAGK4FQyxasoCQx35NVQ';
   const seo = {
     opengraphTitle: 'Favourite Restaurants | World Of Winfield',
     opengraphDescription: "A ranked list of James Winfield's favourite restaurants.",
@@ -36,7 +40,7 @@ export default function FavouritesPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -57,3 +61,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourite-tracks.tsx
+++ b/pages/favourite-tracks.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Container from '../components/container';
 import FavouritesHubLink from '../components/favourites-hub-link';
 import GenreDropdown from '../components/GenreDropdown';
@@ -8,11 +9,27 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
 
-export default function FavouritesPage() {
+const sheetId = '1ifEAiSgIMKrtTJ6fSHNGmQ-kMzR_MyAa-PjvBWOsBRA';
+
+const uniqueSortedColumn = (data: string[][] | null, columnName: string): string[] => {
+  if (!data || data.length === 0) return [];
+  const headerRow = data[0];
+  const columnIndex = headerRow.indexOf(columnName);
+  if (columnIndex === -1) return [];
+
+  const values = new Set<string>();
+  for (const row of data.slice(1)) {
+    const value = row[columnIndex];
+    if (value) values.add(value);
+  }
+  return Array.from(values).sort();
+};
+
+export default function FavouritesPage({ data }: { data: string[][] | null }) {
   const title = 'Favourite Tracks';
-  const sheetId = '1ifEAiSgIMKrtTJ6fSHNGmQ-kMzR_MyAa-PjvBWOsBRA';
   const columnsToHide = ['Date Added'];
   const indexRequired = false;
   const seo = {
@@ -23,48 +40,11 @@ export default function FavouritesPage() {
 
   const router = useRouter();
   const [selectedGenre, setSelectedGenre] = useState('');
-  const [genres, setGenres] = useState<string[]>([]);
   const [selectedLabel, setSelectedLabel] = useState('');
-  const [labels, setLabels] = useState<string[]>([]);
   const [selectedSort, setSelectedSort] = useState('Artist/Track Name');
 
-  useEffect(() => {
-    async function fetchFilterOptions() {
-      const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_SHEETS_API_KEY;
-      const SHEET_NAME = 'Sheet1';
-      const url = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${SHEET_NAME}?alt=json&key=${API_KEY}`;
-      try {
-        const response = await fetch(url);
-        const json = await response.json();
-        const values: string[][] = json.values;
-        if (!values || values.length === 0) return;
-        const headerRow = values[0];
-
-        const genreIndex = headerRow.indexOf('Genre');
-        if (genreIndex !== -1) {
-          const genreSet = new Set<string>();
-          for (let i = 1; i < values.length; i++) {
-            const genre = values[i][genreIndex];
-            if (genre) genreSet.add(genre);
-          }
-          setGenres(Array.from(genreSet).sort());
-        }
-
-        const labelIndex = headerRow.indexOf('Label');
-        if (labelIndex !== -1) {
-          const labelSet = new Set<string>();
-          for (let i = 1; i < values.length; i++) {
-            const label = values[i][labelIndex];
-            if (label) labelSet.add(label);
-          }
-          setLabels(Array.from(labelSet).sort());
-        }
-      } catch (err) {
-        console.error('Failed to fetch filter options', err);
-      }
-    }
-    fetchFilterOptions();
-  }, [sheetId]);
+  const genres = useMemo(() => uniqueSortedColumn(data, 'Genre'), [data]);
+  const labels = useMemo(() => uniqueSortedColumn(data, 'Label'), [data]);
 
   return (
     <Layout preview={null} title={title} seo={seo}>
@@ -109,7 +89,7 @@ export default function FavouritesPage() {
               </DropdownContainer>
 
               <FavouriteResults
-                sheetId={sheetId}
+                data={data}
                 columnsToHide={columnsToHide}
                 indexRequired={indexRequired}
                 sortBy={selectedSort}
@@ -144,3 +124,12 @@ const DropdownContainer = styled.div`
   justify-content: center;
   gap: 1rem 2rem;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/favourites-results.tsx
+++ b/pages/favourites-results.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { StyledInput } from '../components/core-components';
 import SortDropdown from '../components/SortDropdown';
-import { fetchDataFromGoogleSheets } from '../lib/sheets';
 
 type TypeProps = {
-  sheetId: string;
+  data: string[][] | null;
   columnsToHide?: string[];
   indexRequired?: boolean;
   sortBy?: string;
@@ -23,67 +22,48 @@ const normalize = (s: string): string =>
     .replace(/[^a-z0-9 ]/g, '');
 
 const FavouriteResults = ({
-  sheetId,
+  data: sheetData,
   columnsToHide = [],
   indexRequired = true,
   sortBy,
   genreFilter,
   labelFilter,
 }: TypeProps) => {
-  const [rawData, setRawData] = useState<string[][] | null>(null);
-  const [loading, setLoading] = useState(false);
   const [internalSortBy, setInternalSortBy] = useState('');
-  const [sortColumns, setSortColumns] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
 
   const effectiveSortBy = sortBy !== undefined ? sortBy : internalSortBy;
   const showInternalDropdown = sortBy === undefined;
 
-  // Stable primitive key so the effect dependency compares by value, not array identity.
+  // Stable primitive key so the memo dependency compares by value, not array identity.
   const columnsToHideKey = columnsToHide.join('\x00');
 
-  // Fetch and apply column-hiding once per sheetId/columnsToHide change.
-  // Filter and sort are derived in-memory below — no re-fetch on filter/sort changes.
-  useEffect(() => {
-    const fetchFavouriteData = async (): Promise<void> => {
-      if (sheetId && !loading) {
-        setLoading(true);
-        try {
-          const response = await fetchDataFromGoogleSheets(sheetId);
+  // Apply column-hiding to the server-fetched data once per data/columnsToHide change.
+  // Filter and sort are derived in-memory below.
+  const rawData = useMemo(() => {
+    if (!sheetData || !sheetData.length) return null;
 
-          if (!response || !response.length) {
-            console.error('No data received from Google Sheets');
-            return;
-          }
+    const headerRow = [...sheetData[0]];
+    const dataRows = sheetData.slice(1).map((row) => [...row]);
 
-          const headerRow = [...response[0]];
-          const dataRows = response.slice(1).map((row) => [...row]);
-
-          columnsToHide.forEach((columnName) => {
-            const columnIndex = headerRow.indexOf(columnName);
-            if (columnIndex !== -1) {
-              for (const row of dataRows) {
-                row.splice(columnIndex, 1);
-              }
-              headerRow.splice(columnIndex, 1);
-            }
-          });
-
-          if (sortBy === undefined) {
-            setSortColumns([...headerRow]);
-          }
-
-          setRawData([headerRow, ...dataRows]);
-        } catch (error) {
-          console.error('Error processing sheet data:', error);
-        } finally {
-          setLoading(false);
+    columnsToHide.forEach((columnName) => {
+      const columnIndex = headerRow.indexOf(columnName);
+      if (columnIndex !== -1) {
+        for (const row of dataRows) {
+          row.splice(columnIndex, 1);
         }
+        headerRow.splice(columnIndex, 1);
       }
-    };
+    });
 
-    fetchFavouriteData();
-  }, [sheetId, columnsToHideKey]);
+    return [headerRow, ...dataRows];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sheetData, columnsToHideKey]);
+
+  const sortColumns = useMemo(
+    () => (rawData && sortBy === undefined ? rawData[0] : []),
+    [rawData, sortBy],
+  );
 
   const data = useMemo(() => {
     if (!rawData || rawData.length === 0) return [];

--- a/pages/holiday-wish-list.tsx
+++ b/pages/holiday-wish-list.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import Container from '../components/container';
@@ -6,11 +7,13 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import SortDropdown from '../components/SortDropdown';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
 
-export default function WishListPage() {
+const sheetId = '1GX6KF20f3Nrb3m8T9th7UIV_uuePj4Ivlc_yLgo-4Bo';
+
+export default function WishListPage({ data }: { data: string[][] | null }) {
   const title = 'Holiday Wish List';
-  const sheetId = '1GX6KF20f3Nrb3m8T9th7UIV_uuePj4Ivlc_yLgo-4Bo';
   const seo = {
     opengraphTitle: 'Holiday Wish List | World Of Winfield',
     opengraphDescription:
@@ -46,7 +49,7 @@ export default function WishListPage() {
                   onChange={setSelectedSort}
                 />
               </DropdownContainer>
-              <FavouriteResults sheetId={sheetId} indexRequired={false} sortBy={selectedSort} />
+              <FavouriteResults data={data} indexRequired={false} sortBy={selectedSort} />
             </PostContainer>
           </>
         )}
@@ -71,3 +74,12 @@ const DropdownContainer = styled.div`
   display: flex;
   justify-content: center;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/restaurant-wish-list.tsx
+++ b/pages/restaurant-wish-list.tsx
@@ -1,14 +1,17 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import Container from '../components/container';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
 
-export default function WishListPage() {
+const sheetId = '13gz7lPQ61f_WKQ_xio_QBlUcFB9Dl0yVBynwEadVO_4';
+
+export default function WishListPage({ data }: { data: string[][] | null }) {
   const title = 'Restaurant Wish List';
-  const sheetId = '13gz7lPQ61f_WKQ_xio_QBlUcFB9Dl0yVBynwEadVO_4';
   const seo = {
     opengraphTitle: 'Restaurant Wish List | World Of Winfield',
     opengraphDescription:
@@ -36,7 +39,7 @@ export default function WishListPage() {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults sheetId={sheetId} />
+              <FavouriteResults data={data} />
             </PostContainer>
           </>
         )}
@@ -55,3 +58,12 @@ const PostContainer = styled.article`
 const StyledPostHeader = styled.div`
   margin: 0 auto;
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await fetchDataFromGoogleSheets(sheetId);
+
+  return {
+    props: { data },
+    revalidate: 3600,
+  };
+};

--- a/pages/wants.tsx
+++ b/pages/wants.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import Container from '../components/container';
@@ -6,12 +7,21 @@ import { StyledButton } from '../components/core-components';
 import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
+import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
 
-export default function WantsPage() {
-  const [selectedType, setSelectedType] = useState<string | null>(null);
+const holidayWishListSheetId = '1GX6KF20f3Nrb3m8T9th7UIV_uuePj4Ivlc_yLgo-4Bo';
+const restaurantWishListSheetId = '13gz7lPQ61f_WKQ_xio_QBlUcFB9Dl0yVBynwEadVO_4';
 
-  const handleTypeClick = (type: string) => {
+type WantsPageProps = {
+  wantToVisitData: string[][] | null;
+  wantToEatData: string[][] | null;
+};
+
+export default function WantsPage({ wantToVisitData, wantToEatData }: WantsPageProps) {
+  const [selectedType, setSelectedType] = useState<'visit' | 'eat' | null>(null);
+
+  const handleTypeClick = (type: 'visit' | 'eat') => {
     setSelectedType(type);
   };
 
@@ -41,14 +51,11 @@ export default function WantsPage() {
                 />
               </StyledPostHeader>
               <RowOfButtons>
-                <StyledButton onClick={() => handleTypeClick('wantToVisitSheetID')}>
-                  Want To Visit
-                </StyledButton>
-                <StyledButton onClick={() => handleTypeClick('wantToEatHereSheetID')}>
-                  Want To Eat Here
-                </StyledButton>
+                <StyledButton onClick={() => handleTypeClick('visit')}>Want To Visit</StyledButton>
+                <StyledButton onClick={() => handleTypeClick('eat')}>Want To Eat Here</StyledButton>
               </RowOfButtons>
-              {selectedType && <FavouriteResults sheetId={selectedType} />}
+              {selectedType === 'visit' && <FavouriteResults data={wantToVisitData} />}
+              {selectedType === 'eat' && <FavouriteResults data={wantToEatData} />}
             </PostContainer>
           </>
         )}
@@ -81,3 +88,15 @@ const RowOfButtons = styled.div`
     margin: 0.5rem;
   }
 `;
+
+export const getStaticProps: GetStaticProps = async () => {
+  const [wantToVisitData, wantToEatData] = await Promise.all([
+    fetchDataFromGoogleSheets(holidayWishListSheetId),
+    fetchDataFromGoogleSheets(restaurantWishListSheetId),
+  ]);
+
+  return {
+    props: { wantToVisitData, wantToEatData },
+    revalidate: 3600,
+  };
+};


### PR DESCRIPTION
## Summary

- Moves `FavouriteResults` (used by all 13 favourites/wish-list pages) from client-side `useEffect` fetching to server-side `getStaticProps` with `revalidate: 3600`, matching the ISR pattern already used by `blog.tsx`/`index.tsx`.
- `FavouriteResults` now takes fetched rows via a `data` prop instead of fetching itself from a `sheetId`.
- `favourite-tracks.tsx` no longer makes a second, duplicate client-side fetch just to build its genre/label dropdown options — those are now derived from the same server-fetched data.
- `wants.tsx` was passing placeholder strings (`'wantToVisitSheetID'` / `'wantToEatHereSheetID'`) instead of real Google Sheet IDs, so its two buttons never actually loaded data. Fixed by fetching both real wish-list sheets at build time and switching between them client-side.
- No cover art in this PR — just the data-fetching plumbing, as scoped in the issue.

Closes #545

## Why

Every one of the 11 per-list cover-art issues (starting with #514) depends on server-side data being available to resolve cover images into. This was a prerequisite blocking all of them.

## Test plan

- [x] `yarn lint` (tsc + biome) passes
- [x] `yarn test` — 356 tests pass, including a rewritten `__tests__/favourites-results.test.tsx` that renders `FavouriteResults` synchronously with a `data` prop instead of mocking `fetchDataFromGoogleSheets`
- [x] `yarn build` — all 13 pages now render as `● (SSG)` with `getStaticProps`/1h revalidate, and the generated static HTML contains real sheet data (spot-checked `favourite-books.html` and `wants.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)