### PR TITLE
feat: cover art cards for Favourite Movies (TMDB API)

### DIFF
--- a/components/FavouriteCoverGrid.tsx
+++ b/components/FavouriteCoverGrid.tsx
@@ -41,7 +41,8 @@ function FavouriteCoverGrid({
   coverArtByTitle,
   indexRequired,
 }: Props): JSX.Element {
-  const titleIndex = headerRow.indexOf('Title');
+  const titleIndex =
+    headerRow.indexOf('Title') !== -1 ? headerRow.indexOf('Title') : headerRow.indexOf('Name');
   const authorIndex = headerRow.indexOf('Author');
   const scoreIndex = headerRow.indexOf('Score');
 

--- a/lib/tmdb.test.ts
+++ b/lib/tmdb.test.ts
@@ -1,0 +1,120 @@
+import { resolveMovieCovers, resolveMovieCoverUrlByTitle } from './tmdb';
+
+describe('resolveMovieCoverUrlByTitle', () => {
+  const originalFetch = global.fetch;
+  const originalApiKey = process.env.TMDB_API_KEY;
+
+  beforeEach(() => {
+    process.env.TMDB_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.TMDB_API_KEY = originalApiKey;
+    jest.restoreAllMocks();
+  });
+
+  it('returns an image.tmdb.org URL when a poster_path is found', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ poster_path: '/abc123.jpg' }] }),
+    }) as unknown as typeof fetch;
+
+    const url = await resolveMovieCoverUrlByTitle({ title: 'Dune' });
+
+    expect(url).toBe('https://image.tmdb.org/t/p/w342/abc123.jpg');
+  });
+
+  it('includes the year in the query string when provided', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ poster_path: '/abc.jpg' }] }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await resolveMovieCoverUrlByTitle({ title: 'Dune', year: '2021' });
+
+    const requestedUrl = fetchMock.mock.calls[0][0] as string;
+    expect(requestedUrl).toContain('query=Dune');
+    expect(requestedUrl).toContain('year=2021');
+  });
+
+  it('returns null when no results are found', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    }) as unknown as typeof fetch;
+
+    const url = await resolveMovieCoverUrlByTitle({ title: 'Some Unknown Movie' });
+
+    expect(url).toBeNull();
+  });
+
+  it('returns null when the response is not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+
+    const url = await resolveMovieCoverUrlByTitle({ title: 'Dune' });
+
+    expect(url).toBeNull();
+  });
+
+  it('returns null and does not throw when fetch rejects', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
+
+    const url = await resolveMovieCoverUrlByTitle({ title: 'Dune' });
+
+    expect(url).toBeNull();
+  });
+
+  it('returns null without calling fetch when title is empty', async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const url = await resolveMovieCoverUrlByTitle({ title: '' });
+
+    expect(url).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null without calling fetch when no API key is configured', async () => {
+    delete process.env.TMDB_API_KEY;
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const url = await resolveMovieCoverUrlByTitle({ title: 'Dune' });
+
+    expect(url).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveMovieCovers', () => {
+  const originalFetch = global.fetch;
+  const originalApiKey = process.env.TMDB_API_KEY;
+
+  beforeEach(() => {
+    process.env.TMDB_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.TMDB_API_KEY = originalApiKey;
+    jest.restoreAllMocks();
+  });
+
+  it('resolves covers for multiple movies keyed by title', async () => {
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      if (url.includes('query=Dune')) {
+        return { ok: true, json: async () => ({ results: [{ poster_path: '/dune.jpg' }] }) };
+      }
+      return { ok: true, json: async () => ({ results: [] }) };
+    }) as unknown as typeof fetch;
+
+    const covers = await resolveMovieCovers([{ title: 'Dune' }, { title: 'Unknown Movie' }]);
+
+    expect(covers.Dune).toBe('https://image.tmdb.org/t/p/w342/dune.jpg');
+    expect(covers['Unknown Movie']).toBeNull();
+  });
+});

--- a/lib/tmdb.ts
+++ b/lib/tmdb.ts
@@ -1,0 +1,48 @@
+const TMDB_SEARCH_URL = 'https://api.themoviedb.org/3/search/movie';
+const TMDB_IMAGE_BASE_URL = 'https://image.tmdb.org/t/p/w342';
+const REQUEST_TIMEOUT_MS = 8000;
+
+export type MovieCoverLookup = {
+  title: string;
+  year?: string;
+};
+
+export const resolveMovieCoverUrlByTitle = async ({
+  title,
+  year,
+}: MovieCoverLookup): Promise<string | null> => {
+  if (!title) return null;
+
+  const apiKey = process.env.TMDB_API_KEY;
+  if (!apiKey) return null;
+
+  try {
+    const params = new URLSearchParams({ api_key: apiKey, query: title });
+    if (year) params.set('year', year);
+
+    const response = await fetch(`${TMDB_SEARCH_URL}?${params.toString()}`, {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+
+    const json = await response.json();
+    const posterPath = json?.results?.[0]?.poster_path;
+
+    return typeof posterPath === 'string' ? `${TMDB_IMAGE_BASE_URL}${posterPath}` : null;
+  } catch (error) {
+    console.error('Error resolving TMDB cover:', error);
+    return null;
+  }
+};
+
+// Keyed by title so lookups survive sorting/filtering in the UI without needing
+// the cover art to travel alongside each row.
+export const resolveMovieCovers = async (
+  movies: MovieCoverLookup[],
+): Promise<Record<string, string | null>> => {
+  const entries = await Promise.all(
+    movies.map(async (movie) => [movie.title, await resolveMovieCoverUrlByTitle(movie)] as const),
+  );
+
+  return Object.fromEntries(entries);
+};

--- a/lib/tmdb.ts
+++ b/lib/tmdb.ts
@@ -1,6 +1,9 @@
 const TMDB_SEARCH_URL = 'https://api.themoviedb.org/3/search/movie';
 const TMDB_IMAGE_BASE_URL = 'https://image.tmdb.org/t/p/w342';
 const REQUEST_TIMEOUT_MS = 8000;
+// TMDB starts returning 429s once too many lookups are in flight at once
+// (observed failures past ~100 concurrent requests against a 236-movie sheet).
+const MAX_CONCURRENT_REQUESTS = 15;
 
 export type MovieCoverLookup = {
   title: string;
@@ -35,13 +38,37 @@ export const resolveMovieCoverUrlByTitle = async ({
   }
 };
 
+// Runs `fn` over `items` with at most `limit` in flight at once, so a large
+// sheet doesn't fire hundreds of simultaneous requests and trip TMDB's rate limit.
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> => {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+
+  return results;
+};
+
 // Keyed by title so lookups survive sorting/filtering in the UI without needing
 // the cover art to travel alongside each row.
 export const resolveMovieCovers = async (
   movies: MovieCoverLookup[],
 ): Promise<Record<string, string | null>> => {
-  const entries = await Promise.all(
-    movies.map(async (movie) => [movie.title, await resolveMovieCoverUrlByTitle(movie)] as const),
+  const entries = await mapWithConcurrency(
+    movies,
+    MAX_CONCURRENT_REQUESTS,
+    async (movie) => [movie.title, await resolveMovieCoverUrlByTitle(movie)] as const,
   );
 
   return Object.fromEntries(entries);

--- a/pages/favourite-movies.tsx
+++ b/pages/favourite-movies.tsx
@@ -8,11 +8,17 @@ import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
 import { fetchDataFromGoogleSheets } from '../lib/sheets';
+import { resolveMovieCovers } from '../lib/tmdb';
 import FavouriteResults from './favourites-results';
 
 const sheetId = '1q3LFzLYqK0tLWHjvHYxFE1IIF-FrOJuqJ6XBIQIEl6U';
 
-export default function FavouritesPage({ data }: { data: string[][] | null }) {
+type FavouritesPageProps = {
+  data: string[][] | null;
+  coverArtByTitle: Record<string, string | null>;
+};
+
+export default function FavouritesPage({ data, coverArtByTitle }: FavouritesPageProps) {
   const title = 'Favourite Movies';
   const seo = {
     opengraphTitle: 'Favourite Movies | World Of Winfield',
@@ -40,7 +46,7 @@ export default function FavouritesPage({ data }: { data: string[][] | null }) {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults data={data} />
+              <FavouriteResults data={data} coverArtByTitle={coverArtByTitle} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -65,8 +71,20 @@ const StyledPostHeader = styled.div`
 export const getStaticProps: GetStaticProps = async () => {
   const data = await fetchDataFromGoogleSheets(sheetId);
 
+  let coverArtByTitle: Record<string, string | null> = {};
+  if (data && data.length > 1) {
+    const headerRow = data[0];
+    const titleIndex = headerRow.indexOf('Name');
+
+    if (titleIndex !== -1) {
+      coverArtByTitle = await resolveMovieCovers(
+        data.slice(1).map((row) => ({ title: row[titleIndex] })),
+      );
+    }
+  }
+
   return {
-    props: { data },
+    props: { data, coverArtByTitle },
     revalidate: 3600,
   };
 };


### PR DESCRIPTION
## Summary
- Adds poster images to the Favourite Movies grid using the TMDB API, reusing the `FavouriteCoverGrid`/`FavouriteResults` plumbing added for Favourite Books in #546.
- Movies sheet has no Title/Year columns, only Name/Language/Score/Comments, so covers are looked up by title against TMDB's search API (free tier) to get a `poster_path`, built into an `image.tmdb.org` URL.
- Resolved server-side in `favourite-movies.tsx`'s `getStaticProps` and keyed by title so the mapping survives client-side sort/filter/search.
- `FavouriteCoverGrid` now falls back to a `Name` column when there's no `Title` column, since the two favourites sheets use different headers for the same concept.
- Movies with no resolvable cover fall back to the existing placeholder card (accent colour + title initials).
- Requires a `TMDB_API_KEY` env var (added locally to `.env`, not committed — needs to be added to production env as well).

Closes #547

## Test plan
- [x] `yarn jest lib/tmdb.test.ts` — new unit tests for cover resolution (poster found, year param, no results, non-ok response, fetch rejection, empty title, missing API key)
- [x] `yarn jest __tests__/FavouriteCoverGrid.test.tsx __tests__/favourites-results.test.tsx` — existing tests still pass with the Title/Name fallback
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn build` — verified against the live Movies sheet and a real TMDB key; the vast majority of movies resolve a poster, with only a couple of misses traced to typos in the sheet data (e.g. "Levianthan")

🤖 Generated with [Claude Code](https://claude.com/claude-code)