### PR TITLE
Fall back to placeholder cover when a book cover image errors

### DIFF
--- a/__tests__/FavouriteCoverGrid.test.tsx
+++ b/__tests__/FavouriteCoverGrid.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
 import FavouriteCoverGrid from '../components/FavouriteCoverGrid';
@@ -36,6 +36,23 @@ describe('FavouriteCoverGrid', () => {
 
     expect(screen.queryByAltText('Cover of Neuromancer')).not.toBeInTheDocument();
     expect(screen.getByText('N')).toBeInTheDocument();
+  });
+
+  it('falls back to the placeholder when the cover image fails to load', () => {
+    render(
+      <FavouriteCoverGrid
+        headerRow={headerRow}
+        rows={rows}
+        coverArtByTitle={{ Dune: 'https://covers.openlibrary.org/b/id/1-M.jpg', Neuromancer: null }}
+        indexRequired
+      />,
+    );
+
+    const img = screen.getByAltText('Cover of Dune');
+    fireEvent.error(img);
+
+    expect(screen.queryByAltText('Cover of Dune')).not.toBeInTheDocument();
+    expect(screen.getByText('D')).toBeInTheDocument();
   });
 
   it('renders rank badges when indexRequired is true', () => {

--- a/components/FavouriteCoverGrid.tsx
+++ b/components/FavouriteCoverGrid.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import type { JSX } from 'react';
+import { useState } from 'react';
 import { colours } from '../pages/_app';
 
 type Props = {
@@ -35,6 +36,33 @@ const initialsFor = (title: string): string => {
     .join('');
 };
 
+// covers.openlibrary.org and the WordPress image proxy both sometimes return an
+// error (or a broken "not found" image) for a URL that Open Library reported as
+// valid, so we can't trust coverUrl alone — a broken <img> reads worse than the
+// placeholder, so fall back to it as soon as the browser fails to load the image.
+function BookCover({ title, coverUrl }: { title: string; coverUrl?: string | null }): JSX.Element {
+  const [hasErrored, setHasErrored] = useState(false);
+
+  if (!coverUrl || hasErrored) {
+    return (
+      <Placeholder style={{ backgroundColor: placeholderColourFor(title || 'book') }}>
+        {initialsFor(title || '?')}
+      </Placeholder>
+    );
+  }
+
+  return (
+    <Image
+      alt={`Cover of ${title}`}
+      src={coverUrl}
+      sizes="(max-width: 768px) 40vw, 200px"
+      quality={75}
+      fill
+      onError={() => setHasErrored(true)}
+    />
+  );
+}
+
 function FavouriteCoverGrid({
   headerRow,
   rows,
@@ -57,19 +85,7 @@ function FavouriteCoverGrid({
           <Card key={`${title}-${rowIndex}`}>
             <CoverWrapper>
               {indexRequired && <RankBadge>{rowIndex + 1}</RankBadge>}
-              {coverUrl ? (
-                <Image
-                  alt={`Cover of ${title}`}
-                  src={coverUrl}
-                  sizes="(max-width: 768px) 40vw, 200px"
-                  quality={75}
-                  fill
-                />
-              ) : (
-                <Placeholder style={{ backgroundColor: placeholderColourFor(title || 'book') }}>
-                  {initialsFor(title || '?')}
-                </Placeholder>
-              )}
+              <BookCover title={title} coverUrl={coverUrl} />
             </CoverWrapper>
             <CardBody>
               <CardTitle>{title}</CardTitle>


### PR DESCRIPTION
## Summary
- On `/favourite-books`, a lot of cover images were showing as broken images instead of the nice initials placeholder.
- Open Library's `cover_i`/ISBN lookups can succeed server-side but the actual image URL sometimes 404s or fails to load in the browser (Open Library is known to serve broken/"not found" cover art for some IDs). Previously we only fell back to the placeholder when `coverArtByTitle[title]` was `null` — a URL that resolved but failed to *load* rendered as a broken `<img>`, which looks worse than the placeholder.
- `FavouriteCoverGrid` now renders covers through a small `BookCover` component that tracks image load errors via `onError` on `next/image`, and swaps to the existing colour + initials placeholder as soon as a cover fails to load, same as when no cover URL was found at all.

## Test plan
- [x] `yarn jest __tests__/FavouriteCoverGrid.test.tsx` — added a test asserting the placeholder renders after the `<Image>` fires an `error` event
- [x] `yarn jest __tests__/favourites.test.tsx` — existing suite still passes
- [x] `yarn tsc --noEmit`
- [x] `yarn biome check` on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qhv2wzBXhhyJn49Xck24Tn)_