### PR TITLE
feat: cover art cards for Favourite Countries (local images, no API)

### DIFF
--- a/lib/country-covers.ts
+++ b/lib/country-covers.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+
+// No free image API is used for countries — images are just static files dropped
+// into public/images/countries/, named after the country (e.g. "North Macedonia"
+// -> north-macedonia.jpg). Add images as you get them; any country without a
+// matching file falls back to the initials placeholder, so partial coverage is fine.
+
+const COUNTRY_IMAGES_DIR = path.join(process.cwd(), 'public', 'images', 'countries');
+const SUPPORTED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp'];
+
+const slugify = (name: string): string =>
+  name
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const findCountryImagePath = (name: string): string | null => {
+  const slug = slugify(name);
+  if (!slug) return null;
+
+  for (const extension of SUPPORTED_EXTENSIONS) {
+    const filePath = path.join(COUNTRY_IMAGES_DIR, `${slug}${extension}`);
+    if (fs.existsSync(filePath)) return `/images/countries/${slug}${extension}`;
+  }
+
+  return null;
+};
+
+// Keyed by name so lookups survive sorting/filtering in the UI without needing
+// the cover art to travel alongside each row.
+export const resolveCountryCovers = (names: string[]): Record<string, string | null> =>
+  Object.fromEntries(names.map((name) => [name, findCountryImagePath(name)]));

--- a/pages/favourite-countries.tsx
+++ b/pages/favourite-countries.tsx
@@ -7,12 +7,18 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { resolveCountryCovers } from '../lib/country-covers';
 import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
 
 const sheetId = '1zyzuLzWY0S6mUp-FVjcIa3QFAENcU94WVD9ZF0JWERY';
 
-export default function FavouritesPage({ data }: { data: string[][] | null }) {
+type FavouritesPageProps = {
+  data: string[][] | null;
+  coverArtByTitle: Record<string, string | null>;
+};
+
+export default function FavouritesPage({ data, coverArtByTitle }: FavouritesPageProps) {
   const title = 'Favourite Countries Visited';
   const seo = {
     opengraphTitle: 'Favourite Countries Visited | World Of Winfield',
@@ -40,7 +46,7 @@ export default function FavouritesPage({ data }: { data: string[][] | null }) {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults data={data} />
+              <FavouriteResults data={data} coverArtByTitle={coverArtByTitle} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -65,8 +71,18 @@ const StyledPostHeader = styled.div`
 export const getStaticProps: GetStaticProps = async () => {
   const data = await fetchDataFromGoogleSheets(sheetId);
 
+  let coverArtByTitle: Record<string, string | null> = {};
+  if (data && data.length > 1) {
+    const headerRow = data[0];
+    const nameIndex = headerRow.indexOf('Name');
+
+    if (nameIndex !== -1) {
+      coverArtByTitle = resolveCountryCovers(data.slice(1).map((row) => row[nameIndex]));
+    }
+  }
+
   return {
-    props: { data },
+    props: { data, coverArtByTitle },
     revalidate: 3600,
   };
 };

--- a/public/images/countries/README.md
+++ b/public/images/countries/README.md
@@ -1,0 +1,13 @@
+# Favourite Countries cover images
+
+Drop a photo in here named after the country on the Favourite Countries sheet, slugified
+(lowercase, spaces and punctuation replaced with `-`):
+
+- `Spain` → `spain.jpg`
+- `USA` → `usa.jpg`
+- `North Macedonia` → `north-macedonia.jpg`
+
+Supported extensions: `.jpg`, `.jpeg`, `.png`, `.webp`.
+
+Any country without a matching file falls back to the initials placeholder, so this
+can be filled in gradually — no need to source all of them at once.


### PR DESCRIPTION
## Summary
- Closes #551
- Same approach as Favourite Cities (#550/#578): static images in `public/images/countries/` matched by slugified country name, rather than the Unsplash API — no key needed, images can be added gradually.
- `lib/country-covers.ts` resolves a cover image per country name (`.jpg`/`.jpeg`/`.png`/`.webp`), falling back to `null` (initials placeholder card) when no file exists.
- `favourite-countries.tsx` wires `coverArtByTitle` into the existing `FavouriteResults` → `FavouriteCoverGrid` cover-art rendering path already used by Cities/Movies/DJs.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `npx knip` (no unused-file warnings)
- [ ] Manual check in browser once images are dropped into `public/images/countries/`