### PR TITLE
feat: cover art cards for Holiday Wish List (local images, no API)

### DIFF
--- a/lib/wish-list-covers.ts
+++ b/lib/wish-list-covers.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+
+// No free image API is used for the wish list — images are just static files dropped
+// into public/images/wish-list/, named after the place (e.g. "San Sebastian" ->
+// san-sebastian.jpg). Add images as you get them; any place without a matching
+// file falls back to the initials placeholder, so partial coverage is fine.
+
+const WISH_LIST_IMAGES_DIR = path.join(process.cwd(), 'public', 'images', 'wish-list');
+const SUPPORTED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp'];
+
+const slugify = (name: string): string =>
+  name
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const findWishListImagePath = (name: string): string | null => {
+  const slug = slugify(name);
+  if (!slug) return null;
+
+  for (const extension of SUPPORTED_EXTENSIONS) {
+    const filePath = path.join(WISH_LIST_IMAGES_DIR, `${slug}${extension}`);
+    if (fs.existsSync(filePath)) return `/images/wish-list/${slug}${extension}`;
+  }
+
+  return null;
+};
+
+// Keyed by name so lookups survive sorting/filtering in the UI without needing
+// the cover art to travel alongside each row.
+export const resolveWishListCovers = (names: string[]): Record<string, string | null> =>
+  Object.fromEntries(names.map((name) => [name, findWishListImagePath(name)]));

--- a/pages/holiday-wish-list.tsx
+++ b/pages/holiday-wish-list.tsx
@@ -8,11 +8,17 @@ import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import SortDropdown from '../components/SortDropdown';
 import { fetchDataFromGoogleSheets } from '../lib/sheets';
+import { resolveWishListCovers } from '../lib/wish-list-covers';
 import FavouriteResults from './favourites-results';
 
 const sheetId = '1GX6KF20f3Nrb3m8T9th7UIV_uuePj4Ivlc_yLgo-4Bo';
 
-export default function WishListPage({ data }: { data: string[][] | null }) {
+type WishListPageProps = {
+  data: string[][] | null;
+  coverArtByTitle: Record<string, string | null>;
+};
+
+export default function WishListPage({ data, coverArtByTitle }: WishListPageProps) {
   const title = 'Holiday Wish List';
   const seo = {
     opengraphTitle: 'Holiday Wish List | World Of Winfield',
@@ -49,7 +55,12 @@ export default function WishListPage({ data }: { data: string[][] | null }) {
                   onChange={setSelectedSort}
                 />
               </DropdownContainer>
-              <FavouriteResults data={data} indexRequired={false} sortBy={selectedSort} />
+              <FavouriteResults
+                data={data}
+                indexRequired={false}
+                sortBy={selectedSort}
+                coverArtByTitle={coverArtByTitle}
+              />
             </PostContainer>
           </>
         )}
@@ -78,8 +89,18 @@ const DropdownContainer = styled.div`
 export const getStaticProps: GetStaticProps = async () => {
   const data = await fetchDataFromGoogleSheets(sheetId);
 
+  let coverArtByTitle: Record<string, string | null> = {};
+  if (data && data.length > 1) {
+    const headerRow = data[0];
+    const nameIndex = headerRow.indexOf('Name');
+
+    if (nameIndex !== -1) {
+      coverArtByTitle = resolveWishListCovers(data.slice(1).map((row) => row[nameIndex]));
+    }
+  }
+
   return {
-    props: { data },
+    props: { data, coverArtByTitle },
     revalidate: 3600,
   };
 };

--- a/public/images/wish-list/README.md
+++ b/public/images/wish-list/README.md
@@ -1,0 +1,12 @@
+# Holiday Wish List cover images
+
+Drop a photo in here named after the place on the Holiday Wish List sheet, slugified
+(lowercase, spaces and punctuation replaced with `-`):
+
+- `Gothenburg` → `gothenburg.jpg`
+- `San Sebastian` → `san-sebastian.jpg`
+
+Supported extensions: `.jpg`, `.jpeg`, `.png`, `.webp`.
+
+Any place without a matching file falls back to the initials placeholder, so this
+can be filled in gradually — no need to source all of them at once.


### PR DESCRIPTION
## Summary
- Closes #552
- Same approach as Favourite Cities/Countries: static images in `public/images/wish-list/` matched by slugified place name, rather than the Unsplash API — no key needed, images can be added gradually.
- `lib/wish-list-covers.ts` resolves a cover image per place name (`.jpg`/`.jpeg`/`.png`/`.webp`), falling back to `null` (initials placeholder card) when no file exists.
- `holiday-wish-list.tsx` wires `coverArtByTitle` into the existing `FavouriteResults` → `FavouriteCoverGrid` cover-art rendering path. `indexRequired={false}` is preserved so no rank badge is shown (list is unranked), and existing sort/filter continues to work unchanged.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `npx knip` (no unused-file warnings)
- [ ] Manual check in browser once images are dropped into `public/images/wish-list/`