### PR TITLE
feat: cover art cards for Favourite Beers (brewery images, no API)

### DIFF
--- a/components/FavouriteCoverGrid.tsx
+++ b/components/FavouriteCoverGrid.tsx
@@ -71,16 +71,26 @@ function FavouriteCoverGrid({
   indexRequired,
 }: Props): JSX.Element {
   const titleIndex =
-    headerRow.indexOf('Title') !== -1 ? headerRow.indexOf('Title') : headerRow.indexOf('Name');
-  const authorIndex = headerRow.indexOf('Author');
+    ['Title', 'Name', 'Beer Name']
+      .map((header) => headerRow.indexOf(header))
+      .find((index) => index !== -1) ?? -1;
+  const subtitleIndex =
+    ['Author', 'Brewery', 'Country']
+      .map((header) => headerRow.indexOf(header))
+      .find((index) => index !== -1) ?? -1;
   const scoreIndex = headerRow.indexOf('Score');
+  const styleIndex = headerRow.indexOf('Style');
+  const abvIndex = headerRow.indexOf('ABV');
 
   return (
     <Grid>
       {rows.map((row, rowIndex) => {
         const title = row[titleIndex] || '';
-        const author = authorIndex !== -1 ? row[authorIndex] : undefined;
+        const author = subtitleIndex !== -1 ? row[subtitleIndex] : undefined;
         const score = scoreIndex !== -1 ? row[scoreIndex] : undefined;
+        const style = styleIndex !== -1 ? row[styleIndex] : undefined;
+        const abv = abvIndex !== -1 ? row[abvIndex] : undefined;
+        const meta = [style, abv].filter(Boolean).join(' · ');
         const coverUrl = coverArtByTitle[title];
 
         return (
@@ -92,6 +102,7 @@ function FavouriteCoverGrid({
             <CardBody>
               <CardTitle>{title}</CardTitle>
               {author && <CardAuthor>{author}</CardAuthor>}
+              {meta && <CardMeta>{meta}</CardMeta>}
               {score && <CardScore>{score}</CardScore>}
             </CardBody>
           </Card>
@@ -165,6 +176,12 @@ const CardTitle = styled.p`
 `;
 
 const CardAuthor = styled.p`
+  margin: 0.15rem 0 0;
+  font-size: 0.75rem;
+  opacity: 0.8;
+`;
+
+const CardMeta = styled.p`
   margin: 0.15rem 0 0;
   font-size: 0.75rem;
   opacity: 0.8;

--- a/lib/beer-covers.ts
+++ b/lib/beer-covers.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+
+// No API is used for beers — a search-by-name lookup against Open Food Facts or
+// Untappd would be too unreliable for a curated list (mismatched labels, missing
+// entries), and Untappd's API is closed to new keys anyway. Instead this reuses
+// one static image per brewery (a logo, dropped into public/images/beers/,
+// named after the brewery e.g. "Moor Beer Company" -> moor-beer-company.jpg)
+// across every beer from that brewery, rather than trying to source a photo of
+// each individual beer. Any brewery without a matching file falls back to the
+// initials placeholder, so partial coverage is fine.
+
+const BEER_IMAGES_DIR = path.join(process.cwd(), 'public', 'images', 'beers');
+const SUPPORTED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp'];
+
+const slugify = (name: string): string =>
+  name
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const findBreweryImagePath = (brewery: string): string | null => {
+  const slug = slugify(brewery);
+  if (!slug) return null;
+
+  for (const extension of SUPPORTED_EXTENSIONS) {
+    const filePath = path.join(BEER_IMAGES_DIR, `${slug}${extension}`);
+    if (fs.existsSync(filePath)) return `/images/beers/${slug}${extension}`;
+  }
+
+  return null;
+};
+
+// Keyed by beer name (what the grid displays as the card title), each pointing
+// at its brewery's shared image.
+export const resolveBeerCovers = (
+  entries: { beerName: string; brewery: string }[],
+): Record<string, string | null> =>
+  Object.fromEntries(
+    entries.map(({ beerName, brewery }) => [beerName, findBreweryImagePath(brewery)]),
+  );

--- a/pages/favourite-beers.tsx
+++ b/pages/favourite-beers.tsx
@@ -7,12 +7,18 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { resolveBeerCovers } from '../lib/beer-covers';
 import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
 
 const sheetId = '1pNNIw849xWrQHtDptwInGs6Un0AZh-fgXUssC3XIrHM';
 
-export default function FavouritesPage({ data }: { data: string[][] | null }) {
+type FavouritesPageProps = {
+  data: string[][] | null;
+  coverArtByTitle: Record<string, string | null>;
+};
+
+export default function FavouritesPage({ data, coverArtByTitle }: FavouritesPageProps) {
   const title = 'Favourite Beer';
   const seo = {
     opengraphTitle: 'Favourite Beers | World Of Winfield',
@@ -40,7 +46,7 @@ export default function FavouritesPage({ data }: { data: string[][] | null }) {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults data={data} />
+              <FavouriteResults data={data} coverArtByTitle={coverArtByTitle} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -65,8 +71,21 @@ const StyledPostHeader = styled.div`
 export const getStaticProps: GetStaticProps = async () => {
   const data = await fetchDataFromGoogleSheets(sheetId);
 
+  let coverArtByTitle: Record<string, string | null> = {};
+  if (data && data.length > 1) {
+    const headerRow = data[0];
+    const breweryIndex = headerRow.indexOf('Brewery');
+    const beerNameIndex = headerRow.indexOf('Beer Name');
+
+    if (breweryIndex !== -1 && beerNameIndex !== -1) {
+      coverArtByTitle = resolveBeerCovers(
+        data.slice(1).map((row) => ({ beerName: row[beerNameIndex], brewery: row[breweryIndex] })),
+      );
+    }
+  }
+
   return {
-    props: { data },
+    props: { data, coverArtByTitle },
     revalidate: 3600,
   };
 };

--- a/public/images/beers/README.md
+++ b/public/images/beers/README.md
@@ -1,0 +1,17 @@
+# Favourite Beers cover images
+
+Drop a logo/photo in here named after the **brewery** (not the individual beer)
+on the Favourite Beers sheet, slugified (lowercase, spaces and punctuation
+replaced with `-`):
+
+- `Roosters Brewing` → `roosters-brewing.jpg`
+- `Moor Beer Company` → `moor-beer-company.jpg`
+
+One image per brewery is reused across every beer from that brewery — a
+photo of each individual beer isn't realistic to source for most of the list,
+but a brewery logo usually is.
+
+Supported extensions: `.jpg`, `.jpeg`, `.png`, `.webp`.
+
+Any brewery without a matching file falls back to the initials placeholder,
+so this can be filled in gradually — no need to source all of them at once.


### PR DESCRIPTION
## Summary
- Closes #553
- Untappd's API is closed to new keys, and Open Food Facts search-by-name matching would be too unreliable for a curated list (per the issue's own "budget time for a fallback-heavy implementation" note) — so this skips both and reuses one static brewery image across every beer from that brewery, similar to the local-image approach used for Cities/Countries/Wish List.
- `lib/beer-covers.ts` resolves a cover image per `Brewery` (`.jpg`/`.jpeg`/`.png`/`.webp`), keyed against `Beer Name` for the grid lookup, falling back to the initials placeholder when no file exists.
- `favourite-beers.tsx` wires `coverArtByTitle` into `FavouriteResults` → `FavouriteCoverGrid`, same as the other cover-art pages.
- `FavouriteCoverGrid.tsx` is generalised: title column lookup now also matches `Beer Name`, subtitle lookup now also matches `Brewery` and `Country`, and a new Style/ABV meta line renders under the subtitle when those columns exist. The `Country` subtitle addition is generic, so it also surfaces country beneath the city on the Holiday Wish List cards (#552, once both PRs are merged).

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `npx knip` (no unused-file warnings)
- [ ] Manual check in browser once brewery logos are dropped into `public/images/beers/`