### PR TITLE
feat: cover art cards for Favourite Restaurants (local images, no API)

### DIFF
--- a/components/FavouriteCoverGrid.tsx
+++ b/components/FavouriteCoverGrid.tsx
@@ -81,6 +81,7 @@ function FavouriteCoverGrid({
   const scoreIndex = headerRow.indexOf('Score');
   const styleIndex = headerRow.indexOf('Style');
   const abvIndex = headerRow.indexOf('ABV');
+  const dateIndex = headerRow.indexOf('Date');
 
   return (
     <Grid>
@@ -90,6 +91,7 @@ function FavouriteCoverGrid({
         const score = scoreIndex !== -1 ? row[scoreIndex] : undefined;
         const style = styleIndex !== -1 ? row[styleIndex] : undefined;
         const abv = abvIndex !== -1 ? row[abvIndex] : undefined;
+        const date = dateIndex !== -1 ? row[dateIndex] : undefined;
         const meta = [style, abv].filter(Boolean).join(' · ');
         const coverUrl = coverArtByTitle[title];
 
@@ -104,6 +106,7 @@ function FavouriteCoverGrid({
               {author && <CardAuthor>{author}</CardAuthor>}
               {meta && <CardMeta>{meta}</CardMeta>}
               {score && <CardScore>{score}</CardScore>}
+              {date && <CardDate>{date}</CardDate>}
             </CardBody>
           </Card>
         );
@@ -198,6 +201,12 @@ const CardMeta = styled.p`
 `;
 
 const CardScore = styled.p`
+  margin: 0.15rem 0 0;
+  font-size: 0.75rem;
+  opacity: 0.8;
+`;
+
+const CardDate = styled.p`
   margin: 0.15rem 0 0;
   font-size: 0.75rem;
   opacity: 0.8;

--- a/lib/restaurant-covers.ts
+++ b/lib/restaurant-covers.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+// Google Places Photos needs an API key with billing enabled, and the same
+// search-by-name unreliability that hit beers/cheese would apply here too -
+// so this uses one static image per restaurant, dropped into
+// public/images/restaurants/, named after the restaurant (e.g. "Quo Vadis" ->
+// quo-vadis.jpg). Add images as you get them; any restaurant without a
+// matching file falls back to the initials placeholder, so partial coverage
+// is fine.
+
+const RESTAURANT_IMAGES_DIR = path.join(process.cwd(), 'public', 'images', 'restaurants');
+const SUPPORTED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp'];
+
+const slugify = (name: string): string =>
+  name
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const findRestaurantImagePath = (name: string): string | null => {
+  const slug = slugify(name);
+  if (!slug) return null;
+
+  for (const extension of SUPPORTED_EXTENSIONS) {
+    const filePath = path.join(RESTAURANT_IMAGES_DIR, `${slug}${extension}`);
+    if (fs.existsSync(filePath)) return `/images/restaurants/${slug}${extension}`;
+  }
+
+  return null;
+};
+
+// Keyed by name so lookups survive sorting/filtering in the UI without needing
+// the cover art to travel alongside each row.
+export const resolveRestaurantCovers = (names: string[]): Record<string, string | null> =>
+  Object.fromEntries(names.map((name) => [name, findRestaurantImagePath(name)]));

--- a/pages/favourite-restaurants.tsx
+++ b/pages/favourite-restaurants.tsx
@@ -7,12 +7,18 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { resolveRestaurantCovers } from '../lib/restaurant-covers';
 import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
 
 const sheetId = '1J1znKQxeNR3Y6Q1mEPzZyMfCAGK4FQyxasoCQx35NVQ';
 
-export default function FavouritesPage({ data }: { data: string[][] | null }) {
+type FavouritesPageProps = {
+  data: string[][] | null;
+  coverArtByTitle: Record<string, string | null>;
+};
+
+export default function FavouritesPage({ data, coverArtByTitle }: FavouritesPageProps) {
   const title = 'Favourite Restaurants';
   const seo = {
     opengraphTitle: 'Favourite Restaurants | World Of Winfield',
@@ -40,7 +46,7 @@ export default function FavouritesPage({ data }: { data: string[][] | null }) {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults data={data} />
+              <FavouriteResults data={data} coverArtByTitle={coverArtByTitle} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -65,8 +71,18 @@ const StyledPostHeader = styled.div`
 export const getStaticProps: GetStaticProps = async () => {
   const data = await fetchDataFromGoogleSheets(sheetId);
 
+  let coverArtByTitle: Record<string, string | null> = {};
+  if (data && data.length > 1) {
+    const headerRow = data[0];
+    const nameIndex = headerRow.indexOf('Name');
+
+    if (nameIndex !== -1) {
+      coverArtByTitle = resolveRestaurantCovers(data.slice(1).map((row) => row[nameIndex]));
+    }
+  }
+
   return {
-    props: { data },
+    props: { data, coverArtByTitle },
     revalidate: 3600,
   };
 };

--- a/public/images/restaurants/README.md
+++ b/public/images/restaurants/README.md
@@ -1,0 +1,12 @@
+# Favourite Restaurants cover images
+
+Drop a photo in here named after the restaurant on the Favourite Restaurants
+sheet, slugified (lowercase, spaces and punctuation replaced with `-`):
+
+- `Quo Vadis` → `quo-vadis.jpg`
+- `Chick'n'Sours` → `chick-n-sours.jpg`
+
+Supported extensions: `.jpg`, `.jpeg`, `.png`, `.webp`.
+
+Any restaurant without a matching file falls back to the initials placeholder,
+so this can be filled in gradually — no need to source all of them at once.


### PR DESCRIPTION
## Summary
- Closes #555.
- Adds cover art cards to the Favourite Restaurants list, reusing the static-image pattern already established for beers/cheese (#553, #554) rather than Google Places Photos, which needs a billed API key and would hit the same search-by-name unreliability those two ran into.
- `lib/restaurant-covers.ts` resolves a restaurant's photo from `public/images/restaurants/<slug>.jpg` at build time via `getStaticProps`, keyed by the sheet's `Name` column.
- No images have been sourced yet, so every card currently falls back to the initials placeholder — same as beers' initial commit. Coverage can be filled in gradually per `public/images/restaurants/README.md`.
- `FavouriteCoverGrid` already handles `Name` as a title column and `Score` as a meta line, so no changes were needed there.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn build` — `/favourite-restaurants` prerenders successfully, cards render with initials placeholders