### PR TITLE
feat: cover art cards for Favourite Articles (OG image scraping)

### DIFF
--- a/components/FavouriteCoverGrid.tsx
+++ b/components/FavouriteCoverGrid.tsx
@@ -71,7 +71,7 @@ function FavouriteCoverGrid({
   indexRequired,
 }: Props): JSX.Element {
   const titleIndex =
-    ['Title', 'Name', 'Beer Name']
+    ['Title', 'Name', 'Beer Name', 'About']
       .map((header) => headerRow.indexOf(header))
       .find((index) => index !== -1) ?? -1;
   const subtitleIndex =

--- a/components/FavouriteCoverGrid.tsx
+++ b/components/FavouriteCoverGrid.tsx
@@ -81,7 +81,10 @@ function FavouriteCoverGrid({
   const scoreIndex = headerRow.indexOf('Score');
   const styleIndex = headerRow.indexOf('Style');
   const abvIndex = headerRow.indexOf('ABV');
-  const dateIndex = headerRow.indexOf('Date');
+  const dateIndex =
+    ['Date', 'Date Read']
+      .map((header) => headerRow.indexOf(header))
+      .find((index) => index !== -1) ?? -1;
 
   return (
     <Grid>

--- a/components/FavouriteCoverGrid.tsx
+++ b/components/FavouriteCoverGrid.tsx
@@ -85,6 +85,7 @@ function FavouriteCoverGrid({
     ['Date', 'Date Read']
       .map((header) => headerRow.indexOf(header))
       .find((index) => index !== -1) ?? -1;
+  const linkIndex = headerRow.indexOf('Link');
 
   return (
     <Grid>
@@ -97,6 +98,8 @@ function FavouriteCoverGrid({
         const date = dateIndex !== -1 ? row[dateIndex] : undefined;
         const meta = [style, abv].filter(Boolean).join(' · ');
         const coverUrl = coverArtByTitle[title];
+        const rawLink = linkIndex !== -1 ? row[linkIndex] : undefined;
+        const link = /^https?:\/\//i.test(rawLink || '') ? rawLink : undefined;
 
         return (
           <Card key={`${title}-${rowIndex}`}>
@@ -110,6 +113,11 @@ function FavouriteCoverGrid({
               {meta && <CardMeta>{meta}</CardMeta>}
               {score && <CardScore>{score}</CardScore>}
               {date && <CardDate>{date}</CardDate>}
+              {link && (
+                <CardLink href={link} target="_blank" rel="noopener noreferrer">
+                  Read article →
+                </CardLink>
+              )}
             </CardBody>
           </Card>
         );
@@ -213,6 +221,14 @@ const CardDate = styled.p`
   margin: 0.15rem 0 0;
   font-size: 0.75rem;
   opacity: 0.8;
+`;
+
+const CardLink = styled.a`
+  display: inline-block;
+  margin: 0.15rem 0 0;
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: ${colours.azure};
 `;
 
 export default FavouriteCoverGrid;

--- a/lib/article-covers.ts
+++ b/lib/article-covers.ts
@@ -24,7 +24,7 @@ const isHttpUrl = (value: string | undefined): value is string => {
 // The sheet's Link column is sometimes just the article title again (data-entry
 // slip), so links that don't parse as an http(s) URL are skipped rather than
 // fetched.
-export const resolveArticleCoverUrl = async (link: string | undefined): Promise<string | null> => {
+const resolveArticleCoverUrl = async (link: string | undefined): Promise<string | null> => {
   if (!isHttpUrl(link)) return null;
 
   try {

--- a/lib/article-covers.ts
+++ b/lib/article-covers.ts
@@ -1,0 +1,81 @@
+const REQUEST_TIMEOUT_MS = 8000;
+// Scraping dozens of arbitrary third-party sites at build time - be conservative
+// about how many are in flight at once so one slow host doesn't stall the rest.
+const MAX_CONCURRENT_REQUESTS = 5;
+
+const OG_IMAGE_PATTERN =
+  /<meta[^>]+(?:property|name)=["']og:image["'][^>]+content=["']([^"']+)["'][^>]*>|<meta[^>]+content=["']([^"']+)["'][^>]+(?:property|name)=["']og:image["'][^>]*>/i;
+
+export type ArticleCoverLookup = {
+  title: string;
+  link?: string;
+};
+
+const isHttpUrl = (value: string | undefined): value is string => {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+// The sheet's Link column is sometimes just the article title again (data-entry
+// slip), so links that don't parse as an http(s) URL are skipped rather than
+// fetched.
+export const resolveArticleCoverUrl = async (link: string | undefined): Promise<string | null> => {
+  if (!isHttpUrl(link)) return null;
+
+  try {
+    const response = await fetch(link, {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; WorldOfWinfieldBot/1.0)' },
+    });
+    if (!response.ok) return null;
+
+    const html = await response.text();
+    const match = html.match(OG_IMAGE_PATTERN);
+    const imageUrl = match?.[1] ?? match?.[2];
+
+    return isHttpUrl(imageUrl) ? imageUrl : null;
+  } catch (error) {
+    console.error(`Error resolving og:image for ${link}:`, error);
+    return null;
+  }
+};
+
+// Runs `fn` over `items` with at most `limit` in flight at once.
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> => {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+
+  return results;
+};
+
+// Keyed by title so lookups survive sorting/filtering in the UI without needing
+// the cover art to travel alongside each row.
+export const resolveArticleCovers = async (
+  articles: ArticleCoverLookup[],
+): Promise<Record<string, string | null>> => {
+  const entries = await mapWithConcurrency(
+    articles,
+    MAX_CONCURRENT_REQUESTS,
+    async (article) => [article.title, await resolveArticleCoverUrl(article.link)] as const,
+  );
+
+  return Object.fromEntries(entries);
+};

--- a/pages/favourite-articles.tsx
+++ b/pages/favourite-articles.tsx
@@ -7,12 +7,18 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
+import { resolveArticleCovers } from '../lib/article-covers';
 import { fetchDataFromGoogleSheets } from '../lib/sheets';
 import FavouriteResults from './favourites-results';
 
 const sheetId = '1R928oTM4hiTFXZ6Ww9-2pMKLAWy2Wjf3Z9xrXC6GTa0';
 
-export default function FavouritesPage({ data }: { data: string[][] | null }) {
+type FavouritesPageProps = {
+  data: string[][] | null;
+  coverArtByTitle: Record<string, string | null>;
+};
+
+export default function FavouritesPage({ data, coverArtByTitle }: FavouritesPageProps) {
   const title = 'Favourite Articles Read';
   const seo = {
     opengraphTitle: 'Favourite Articles | World Of Winfield',
@@ -40,7 +46,7 @@ export default function FavouritesPage({ data }: { data: string[][] | null }) {
                 />
               </StyledPostHeader>
 
-              <FavouriteResults data={data} />
+              <FavouriteResults data={data} coverArtByTitle={coverArtByTitle} />
               <ShareBar title={title} url={`https://worldofwinfield.co.uk${router.asPath}`} />
               <FavouritesHubLink />
             </PostContainer>
@@ -65,8 +71,24 @@ const StyledPostHeader = styled.div`
 export const getStaticProps: GetStaticProps = async () => {
   const data = await fetchDataFromGoogleSheets(sheetId);
 
+  let coverArtByTitle: Record<string, string | null> = {};
+  if (data && data.length > 1) {
+    const headerRow = data[0];
+    const titleIndex = headerRow.indexOf('About');
+    const linkIndex = headerRow.indexOf('Link');
+
+    if (titleIndex !== -1) {
+      coverArtByTitle = await resolveArticleCovers(
+        data.slice(1).map((row) => ({
+          title: row[titleIndex],
+          link: linkIndex !== -1 ? row[linkIndex] : undefined,
+        })),
+      );
+    }
+  }
+
   return {
-    props: { data },
+    props: { data, coverArtByTitle },
     revalidate: 3600,
   };
 };


### PR DESCRIPTION
## Summary
- Closes #556.
- Adds cover art cards to the Favourite Articles list by scraping each article's `og:image` meta tag at build/ISR time (`lib/article-covers.ts`), keyed by the sheet's `About` column.
- Scraping happens in `getStaticProps` only, not on live page views, per the issue's note about avoiding slow/broken third-party fetches on real traffic.
- Falls back to the initials placeholder when the `Link` cell isn't a valid http(s) URL (one row in the current sheet just repeats the title), the fetch fails, or no `og:image` tag is present.
- `FavouriteCoverGrid`'s title column now also recognises `About` alongside `Title`/`Name`/`Beer Name`.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn build` — `/favourite-articles` prerenders successfully; verified several real og:image URLs were resolved and rendered, and the row with an invalid link fell back to the placeholder