### PR TITLE
fix(a11y): accessibility and SEO improvements across site

### DIFF
--- a/components/FavouriteCoverGrid.tsx
+++ b/components/FavouriteCoverGrid.tsx
@@ -236,10 +236,10 @@ const CardLink = styled.a`
   margin: 0.15rem 0 0;
   font-size: 0.75rem;
   font-weight: bold;
-  color: ${colours.azure};
+  color: #1967c6;
 
   &:focus-visible {
-    outline: 2px solid ${colours.azure};
+    outline: 2px solid #1967c6;
     outline-offset: 2px;
   }
 `;

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { type JSX, useMemo } from 'react';
 import { sanitize, stripExternalLinks } from '../lib/sanitize';
 import type { HeroPostProps } from '../lib/types';
-import { StyledButton } from './core-components';
+import { colours } from '../pages/_app';
 import PostHeader from './post-header';
 
 export default function HeroPost({
@@ -27,16 +27,15 @@ export default function HeroPost({
             author={author}
             slug={slug}
             heroPost={true}
+            headingLevel="h2"
             caption={featuredImage?.node.caption}
           />
         </div>
         <StyledExcerptContainer>
           <StyledExcerpt dangerouslySetInnerHTML={{ __html: sanitizedExcerpt }} />
-          <StyledButton>
-            <Link href={slug} aria-label={`Read more about ${title}`}>
-              Read More
-            </Link>
-          </StyledButton>
+          <ReadMoreLink href={slug} aria-label={`Read more about ${title}`}>
+            Read More
+          </ReadMoreLink>
         </StyledExcerptContainer>
       </div>
     </StyledSection>
@@ -63,6 +62,27 @@ const StyledExcerpt = styled.div`
 
   p {
     word-wrap: break-word;
+  }
+`;
+
+const ReadMoreLink = styled(Link)`
+  display: inline-block;
+  padding: 10px;
+  font-size: 1rem;
+  min-width: 100px;
+  background-color: ${colours.pink};
+  color: ${colours.white};
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.white};
+    outline-offset: 2px;
   }
 `;
 

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -32,7 +32,7 @@ export default function Meta({
 
   return (
     <Head>
-      <title>{title || opengraphTitle}</title>
+      <title>{title || opengraphTitle || 'World Of Winfield'}</title>
       <link rel="canonical" href={canonicalUrl} />
       <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -73,7 +73,7 @@ export default function Nav(): JSX.Element {
         id="main-nav-list"
         role="list"
         className={isDropdownOpen ? 'open' : ''}
-        aria-hidden={isMobile && !isDropdownOpen}>
+        aria-hidden={isMobile && !isDropdownOpen ? true : undefined}>
         <li>
           <Link href="/" onClick={closeNavOnMobile}>
             Home
@@ -122,6 +122,7 @@ export default function Nav(): JSX.Element {
                   toggleFavouritesDropdown();
                 }}
                 aria-label="Toggle Favourites submenu"
+                aria-haspopup="true"
                 aria-expanded={isFavouritesDropdownOpen}
                 aria-controls="favourites-menu">
                 ▼
@@ -203,6 +204,7 @@ export default function Nav(): JSX.Element {
             <SplitButtonContainer role="group" aria-label="Wish Lists navigation">
               <DropdownButton
                 ref={wishListButtonRef}
+                aria-haspopup="true"
                 aria-expanded={isWishListDropdownOpen}
                 aria-controls="wishlist-menu"
                 onClick={() => toggleWishListDropdown()}>
@@ -221,6 +223,7 @@ export default function Nav(): JSX.Element {
                   toggleWishListDropdown();
                 }}
                 aria-label="Toggle Wish Lists submenu"
+                aria-haspopup="true"
                 aria-expanded={isWishListDropdownOpen}
                 aria-controls="wishlist-menu">
                 ▼
@@ -277,6 +280,7 @@ export default function Nav(): JSX.Element {
                   toggleTravelDropdown();
                 }}
                 aria-label="Toggle Travel submenu"
+                aria-haspopup="true"
                 aria-expanded={isTravelDropdownOpen}
                 aria-controls="travel-menu">
                 ▼

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -119,6 +119,11 @@ const BrowseTopicsBar = styled.nav`
     &:hover {
       text-decoration: underline;
     }
+
+    &:focus-visible {
+      outline: 2px solid #000;
+      outline-offset: 2px;
+    }
   }
 `;
 
@@ -131,6 +136,11 @@ const RssLink = styled.a`
 
   &:hover {
     text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #000;
+    outline-offset: 2px;
   }
 `;
 

--- a/pages/countries-visited.tsx
+++ b/pages/countries-visited.tsx
@@ -83,7 +83,14 @@ const CountryList = ({ transformedData }: CountryListProps): JSX.Element => {
           <ul>
             {transformedData[continent].map((item, index) => (
               <li key={index}>
-                {item.country} {item.visited}
+                {item.country}
+                {item.visited && (
+                  <>
+                    {' '}
+                    <span aria-hidden="true">✔</span>
+                    <VisuallyHidden>(visited)</VisuallyHidden>
+                  </>
+                )}
               </li>
             ))}
           </ul>
@@ -200,6 +207,18 @@ const StatLabel = styled.span`
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-top: 0.25rem;
+`;
+
+const VisuallyHidden = styled.span`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 `;
 
 const ContentContainer = styled.section`

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -128,6 +128,11 @@ const ReadMoreLink = styled(Link)`
   &:hover {
     opacity: 0.85;
   }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.white};
+    outline-offset: 2px;
+  }
 `;
 
 const PostContainer = styled.article<{ isEven: boolean }>`

--- a/pages/music.tsx
+++ b/pages/music.tsx
@@ -128,6 +128,11 @@ const ReadMoreLink = styled(Link)`
   &:hover {
     opacity: 0.85;
   }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.white};
+    outline-offset: 2px;
+  }
 `;
 
 const PostContainer = styled.article<{ isEven: boolean }>`

--- a/pages/politics.tsx
+++ b/pages/politics.tsx
@@ -128,6 +128,11 @@ const ReadMoreLink = styled(Link)`
   &:hover {
     opacity: 0.85;
   }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.white};
+    outline-offset: 2px;
+  }
 `;
 
 const PostContainer = styled.article<{ isEven: boolean }>`

--- a/pages/travel.tsx
+++ b/pages/travel.tsx
@@ -130,6 +130,11 @@ const ReadMoreLink = styled(Link)`
   &:hover {
     opacity: 0.85;
   }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.white};
+    outline-offset: 2px;
+  }
 `;
 
 const PostContainer = styled.article<{ isEven: boolean }>`

--- a/pages/year-in-review/index.tsx
+++ b/pages/year-in-review/index.tsx
@@ -73,4 +73,9 @@ const YearTile = styled(Link)`
   &:hover {
     opacity: 0.85;
   }
+
+  &:focus-visible {
+    outline: 2px solid ${colours.white};
+    outline-offset: -2px;
+  }
 `;


### PR DESCRIPTION
## Summary

Automated accessibility and SEO audit (category: **Accessibility & SEO**, 2026-08-23). Fixes applied across 11 files:

- **Nav `aria-hidden` fix** (`components/nav.tsx`): `aria-hidden={false}` on the visible nav list was incorrect per WAI-ARIA spec (differs from omitting the attribute). Changed to `aria-hidden={isMobile && !isDropdownOpen ? true : undefined}` so desktop renders no attribute at all.
- **Nav dropdown `aria-haspopup`** (`components/nav.tsx`): Added `aria-haspopup="true"` to all three `DropdownArrow` buttons and the Wish Lists `DropdownButton` so screen readers announce popup intent.
- **Invalid `<button><a>` in HeroPost** (`components/hero-post.tsx`): Replaced `<StyledButton><Link>` (renders as `<button><a>`, invalid HTML) with a `ReadMoreLink = styled(Link)` component carrying the same button-like styles. Includes `&:focus-visible` outline.
- **Duplicate `<h1>` on Blog page** (`components/hero-post.tsx`): Added `headingLevel="h2"` to `PostHeader` inside `HeroPost` so the hidden `<h1>The Blog</h1>` in `blog.tsx` is the sole page heading.
- **Missing `focus-visible` on "Read this post" links** (`pages/music.tsx`, `pages/travel.tsx`, `pages/goals.tsx`, `pages/politics.tsx`): Added `&:focus-visible { outline: 2px solid white; }` to each page's `ReadMoreLink`.
- **Missing `focus-visible` on year tiles** (`pages/year-in-review/index.tsx`): Added `&:focus-visible` with inset outline to `YearTile`.
- **Missing `focus-visible` on blog nav links** (`pages/blog.tsx`): Added `&:focus-visible` to `BrowseTopicsBar` `a` styles and `RssLink`.
- **Countries visited checkmark accessibility** (`pages/countries-visited.tsx`): Hid the decorative `✔` from screen readers with `aria-hidden="true"` and added a visually-hidden `(visited)` label via a new `VisuallyHidden` styled component.
- **Contrast fix in FavouriteCoverGrid** (`components/FavouriteCoverGrid.tsx`): `CardLink` color changed from `colours.azure` (#3185FC, ~3.5:1 on white — fails WCAG AA for small text) to `#1967c6` (~5.5:1 — passes WCAG AA).
- **Meta fallback title** (`components/meta.tsx`): Added `|| 'World Of Winfield'` fallback so the `<title>` tag is never empty.

---
_Generated by [Claude Code](https://claude.ai/code/session_017WBQJ6K1A9fiKXsLHf4pRv)_