### PR TITLE
chore(typescript): fix type accuracy bugs and strengthen API return types

### DIFF
--- a/__tests__/slug.test.tsx
+++ b/__tests__/slug.test.tsx
@@ -108,7 +108,7 @@ const mockPost = {
       description: 'Writer',
     },
   },
-  categories: { edges: { node: { name: 'Travel' } } },
+  categories: { edges: [{ node: { name: 'Travel' } }] },
   tags: { edges: [] },
   seo: {
     opengraphDescription: 'Post description',

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -77,8 +77,13 @@ async function fetchAPI<T = any>(query = '', { variables }: FetchAPIOptions = {}
   throw lastError;
 }
 
-export async function getPreviewPost(id: string, idType = 'DATABASE_ID') {
-  const data = await fetchAPI(
+type PreviewPostResponse = { post: { databaseId: number; slug: string; status: string } | null };
+
+export async function getPreviewPost(
+  id: string,
+  idType = 'DATABASE_ID',
+): Promise<{ databaseId: number; slug: string; status: string } | null> {
+  const data = await fetchAPI<PreviewPostResponse>(
     `
     query PreviewPost($id: ID!, $idType: PostIdType!) {
       post(id: $id, idType: $idType) {
@@ -94,8 +99,10 @@ export async function getPreviewPost(id: string, idType = 'DATABASE_ID') {
   return data.post;
 }
 
-export async function getAllPostsWithSlug() {
-  const data = await fetchAPI(`
+type AllPostsWithSlugResponse = { posts: { edges: { node: { slug: string } }[] } };
+
+export async function getAllPostsWithSlug(): Promise<{ edges: { node: { slug: string } }[] }> {
+  const data = await fetchAPI<AllPostsWithSlugResponse>(`
     {
       posts(first: 10000) {
         edges {
@@ -106,7 +113,7 @@ export async function getAllPostsWithSlug() {
       }
     }
   `);
-  return data?.posts;
+  return data.posts;
 }
 
 export async function getFirstPost() {

--- a/lib/open-library.ts
+++ b/lib/open-library.ts
@@ -78,7 +78,11 @@ export const resolveBookCovers = async (
   books: BookCoverLookup[],
 ): Promise<Record<string, string | null>> => {
   const isbnsToLookup = Array.from(
-    new Set(books.filter((book) => book.isbn).map((book) => normalizeIsbn(book.isbn as string))),
+    new Set(
+      books
+        .filter((book): book is BookCoverLookup & { isbn: string } => book.isbn !== undefined)
+        .map((book) => normalizeIsbn(book.isbn)),
+    ),
   );
   const coversByIsbn = await fetchCoversByIsbn(isbnsToLookup);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,7 +22,7 @@ export type SinglePostProps = {
       node: {
         name: string;
       };
-    };
+    }[];
   };
   tags: {
     edges: {
@@ -129,7 +129,7 @@ export type PostsProps = {
         node: {
           name: string;
         };
-      };
+      }[];
     };
   }[];
 };
@@ -233,11 +233,7 @@ export type IndexPageProps = {
     featuredImage: {
       node: {
         mediaDetails: {
-          sizes: {
-            height: number;
-            width: number;
-            sizes: string;
-          };
+          sizes: string;
           height: number;
           width: number;
         };
@@ -267,8 +263,8 @@ export type IndexPageProps = {
         node: {
           mediaDetails: {
             sizes: {
-              height: string;
-              width: string;
+              height: number;
+              width: number;
               sourceUrl: string;
             }[];
             height: number;
@@ -365,7 +361,7 @@ export type PostHeaderProps = {
       node: {
         name: string;
       };
-    };
+    }[];
   };
   slug?: string;
   heroPost?: boolean;
@@ -437,7 +433,7 @@ export type HeroPostProps = {
       node: {
         name: string;
       };
-    };
+    }[];
   };
 };
 


### PR DESCRIPTION
## Summary

Automated TypeScript & typing pass (Sunday 2026-08-23, category selected at random).

### Bug fixes in `lib/types.ts`

- **`categories.edges` missing `[]`** — `SinglePostProps`, `PostsProps`, `PostHeaderProps`, and `HeroPostProps` all typed `categories.edges` as a single object instead of an array. WordPress GraphQL returns categories as an array (the same shape as `tags.edges` on the same types). Any runtime `.map()` or `.length` check on these fields would silently misbehave.

- **`archivePost` sizes `height`/`width` typed as `string`** — `IndexPageProps.archivePost.post.featuredImage.node.mediaDetails.sizes` had `height: string; width: string`. Every other equivalent shape in the type file uses `number`, matching the WordPress API. Changed to `number`.

- **`randomPosts` `mediaDetails.sizes` typed as object** — `IndexPageProps.randomPosts.featuredImage.node.mediaDetails.sizes` was typed as `{ height: number; width: number; sizes: string }` (a self-referential object). The `sizes` field at this level is the HTML `<img sizes="…">` attribute — a plain `string` — consistent with all other `mediaDetails` shapes in the file.

### Stronger return types in `lib/api.ts`

- **`getPreviewPost`** — added `PreviewPostResponse` local type and an explicit `Promise<{ databaseId: number; slug: string; status: string } | null>` return type. Previously implicitly returned `any`.

- **`getAllPostsWithSlug`** — added `AllPostsWithSlugResponse` local type and an explicit `Promise<{ edges: { node: { slug: string } }[] }>` return type. Previously implicitly returned `any`.

### Safer cast in `lib/open-library.ts`

Replaced `book.isbn as string` with a typed filter predicate `(book): book is BookCoverLookup & { isbn: string } => book.isbn !== undefined`. This eliminates the unsafe cast and lets TypeScript narrow the type properly inside `.map()`.

### Test fixture update (`__tests__/slug.test.tsx`)

Updated `mockPost.categories.edges` from a bare object to an array (`[{ node: { name: 'Travel' } }]`) to match the now-correct type definition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6djyrm9RsGavorqSTTv5Q)_