### PR TITLE
test: add unit tests for untested lib cover utilities and search-sheets

### DIFF
--- a/lib/cheese-covers.test.ts
+++ b/lib/cheese-covers.test.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import { resolveCheeseCovers } from './cheese-covers';
+
+jest.mock('fs');
+
+const mockedExistsSync = jest.mocked(fs.existsSync);
+
+beforeEach(() => {
+  mockedExistsSync.mockReturnValue(false);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('resolveCheeseCovers', () => {
+  it('returns the image path when a jpg file exists for the cheese', () => {
+    mockedExistsSync.mockImplementation((filePath) =>
+      String(filePath).endsWith('mature-blue-stilton.jpg'),
+    );
+
+    const result = resolveCheeseCovers(['Mature Blue Stilton']);
+
+    expect(result['Mature Blue Stilton']).toBe('/images/cheese/mature-blue-stilton.jpg');
+  });
+
+  it('returns null when no image file exists for the cheese', () => {
+    const result = resolveCheeseCovers(['Unknown Cheese']);
+
+    expect(result['Unknown Cheese']).toBeNull();
+  });
+
+  it('slugifies cheese names with special characters when looking up files', () => {
+    mockedExistsSync.mockImplementation((filePath) => String(filePath).endsWith('comte-aop.jpg'));
+
+    const result = resolveCheeseCovers(['Comté AOP']);
+
+    expect(result['Comté AOP']).toBe('/images/cheese/comte-aop.jpg');
+  });
+});

--- a/lib/city-covers.test.ts
+++ b/lib/city-covers.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import { resolveCityCovers } from './city-covers';
+
+jest.mock('fs');
+
+const mockedExistsSync = jest.mocked(fs.existsSync);
+
+beforeEach(() => {
+  mockedExistsSync.mockReturnValue(false);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('resolveCityCovers', () => {
+  it('returns the image path when a jpg file exists for the city', () => {
+    mockedExistsSync.mockImplementation((filePath) => String(filePath).endsWith('ibiza-town.jpg'));
+
+    const result = resolveCityCovers(['Ibiza Town']);
+
+    expect(result['Ibiza Town']).toBe('/images/cities/ibiza-town.jpg');
+  });
+
+  it('returns null when no image file exists for the city', () => {
+    const result = resolveCityCovers(['Unknown City']);
+
+    expect(result['Unknown City']).toBeNull();
+  });
+
+  it('resolves multiple cities and keys the result by name', () => {
+    mockedExistsSync.mockImplementation((filePath) => String(filePath).endsWith('paris.jpg'));
+
+    const result = resolveCityCovers(['Paris', 'Unknown City']);
+
+    expect(result['Paris']).toBe('/images/cities/paris.jpg');
+    expect(result['Unknown City']).toBeNull();
+  });
+});

--- a/lib/country-covers.test.ts
+++ b/lib/country-covers.test.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import { resolveCountryCovers } from './country-covers';
+
+jest.mock('fs');
+
+const mockedExistsSync = jest.mocked(fs.existsSync);
+
+beforeEach(() => {
+  mockedExistsSync.mockReturnValue(false);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('resolveCountryCovers', () => {
+  it('returns the image path when a jpg file exists for the country', () => {
+    mockedExistsSync.mockImplementation((filePath) =>
+      String(filePath).endsWith('north-macedonia.jpg'),
+    );
+
+    const result = resolveCountryCovers(['North Macedonia']);
+
+    expect(result['North Macedonia']).toBe('/images/countries/north-macedonia.jpg');
+  });
+
+  it('returns null when no image file exists for the country', () => {
+    const result = resolveCountryCovers(['Unknown Country']);
+
+    expect(result['Unknown Country']).toBeNull();
+  });
+
+  it('checks all supported extensions in order, returning the first match', () => {
+    mockedExistsSync.mockImplementation((filePath) => String(filePath).endsWith('france.webp'));
+
+    const result = resolveCountryCovers(['France']);
+
+    expect(result['France']).toBe('/images/countries/france.webp');
+  });
+});

--- a/lib/restaurant-covers.test.ts
+++ b/lib/restaurant-covers.test.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import { resolveRestaurantCovers } from './restaurant-covers';
+
+jest.mock('fs');
+
+const mockedExistsSync = jest.mocked(fs.existsSync);
+
+beforeEach(() => {
+  mockedExistsSync.mockReturnValue(false);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('resolveRestaurantCovers', () => {
+  it('returns the image path when a jpg file exists for the restaurant', () => {
+    mockedExistsSync.mockImplementation((filePath) => String(filePath).endsWith('quo-vadis.jpg'));
+
+    const result = resolveRestaurantCovers(['Quo Vadis']);
+
+    expect(result['Quo Vadis']).toBe('/images/restaurants/quo-vadis.jpg');
+  });
+
+  it('returns null when no image file exists for the restaurant', () => {
+    const result = resolveRestaurantCovers(['Unknown Restaurant']);
+
+    expect(result['Unknown Restaurant']).toBeNull();
+  });
+
+  it('expands & to "and" when slugifying restaurant names', () => {
+    mockedExistsSync.mockImplementation((filePath) =>
+      String(filePath).endsWith('fish-and-chips.jpg'),
+    );
+
+    const result = resolveRestaurantCovers(['Fish & Chips']);
+
+    expect(result['Fish & Chips']).toBe('/images/restaurants/fish-and-chips.jpg');
+  });
+
+  it('strips apostrophes when slugifying restaurant names', () => {
+    mockedExistsSync.mockImplementation((filePath) => String(filePath).endsWith('mcdonalds.jpg'));
+
+    const result = resolveRestaurantCovers(["McDonald's"]);
+
+    expect(result["McDonald's"]).toBe('/images/restaurants/mcdonalds.jpg');
+  });
+});

--- a/lib/search-sheets.test.ts
+++ b/lib/search-sheets.test.ts
@@ -1,0 +1,18 @@
+import { searchableSheets } from './search-sheets';
+
+describe('searchableSheets', () => {
+  it('has unique keys across all entries', () => {
+    const keys = searchableSheets.map((s) => s.key);
+    const uniqueKeys = new Set(keys);
+
+    expect(uniqueKeys.size).toBe(keys.length);
+  });
+
+  it('every entry has a non-empty sheetId, path, and titleColumn', () => {
+    for (const sheet of searchableSheets) {
+      expect(sheet.sheetId).toBeTruthy();
+      expect(sheet.path).toMatch(/^\//);
+      expect(sheet.titleColumn).toBeTruthy();
+    }
+  });
+});

--- a/lib/wish-list-covers.test.ts
+++ b/lib/wish-list-covers.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import { resolveWishListCovers } from './wish-list-covers';
+
+jest.mock('fs');
+
+const mockedExistsSync = jest.mocked(fs.existsSync);
+
+beforeEach(() => {
+  mockedExistsSync.mockReturnValue(false);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('resolveWishListCovers', () => {
+  it('returns the image path when a jpg file exists for the place', () => {
+    mockedExistsSync.mockImplementation((filePath) =>
+      String(filePath).endsWith('san-sebastian.jpg'),
+    );
+
+    const result = resolveWishListCovers(['San Sebastian']);
+
+    expect(result['San Sebastian']).toBe('/images/wish-list/san-sebastian.jpg');
+  });
+
+  it('returns null when no image file exists for the place', () => {
+    const result = resolveWishListCovers(['Unknown Place']);
+
+    expect(result['Unknown Place']).toBeNull();
+  });
+
+  it('resolves multiple places and keys the result by name', () => {
+    mockedExistsSync.mockImplementation((filePath) => String(filePath).endsWith('tokyo.jpg'));
+
+    const result = resolveWishListCovers(['Tokyo', 'Unknown Place']);
+
+    expect(result['Tokyo']).toBe('/images/wish-list/tokyo.jpg');
+    expect(result['Unknown Place']).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Six `lib/` modules had no test coverage despite the project having well-established test patterns for similar utilities. This PR adds tests for all of them:

- **`lib/cheese-covers.test.ts`** — tests `resolveCheeseCovers`: hit, miss, and NFKD diacritic slugification
- **`lib/city-covers.test.ts`** — tests `resolveCityCovers`: hit, miss, and multi-item keying by name
- **`lib/country-covers.test.ts`** — tests `resolveCountryCovers`: hit, miss, and extension fallback order (`.webp` after `.jpg`/`.jpeg`/`.png`)
- **`lib/restaurant-covers.test.ts`** — tests `resolveRestaurantCovers`: hit, miss, plus the two slugify special cases unique to this module (`&` → `and`, apostrophe stripping)
- **`lib/wish-list-covers.test.ts`** — tests `resolveWishListCovers`: hit, miss, and multi-item keying
- **`lib/search-sheets.test.ts`** — tests the `searchableSheets` static data array for unique keys and non-empty required fields (`sheetId`, `path`, `titleColumn`)

All tests follow the existing `beer-covers` pattern: `jest.mock('fs')`, mock `fs.existsSync` per case, assert on the returned path or `null`.

## Test plan

- [x] All 18 new test cases pass (`yarn test --testPathPatterns="lib/(cheese|city|country|restaurant|wish-list|search-sheets)"`)
- [x] `yarn lint` passes cleanly (formatter issues auto-fixed with `yarn lint:fix`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcKa2AS2UeYvqbE4ZDDdGh)_