### PR TITLE
perf: lazy-load WorldMap and stabilise callback references

### DIFF
--- a/components/post-body.tsx
+++ b/components/post-body.tsx
@@ -1,5 +1,13 @@
 import styled from '@emotion/styled';
-import { type JSX, type MouseEvent, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type JSX,
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { sanitize } from '../lib/sanitize';
 import type { PostBodyProps } from '../lib/types';
 import { colours } from '../pages/_app';
@@ -66,6 +74,8 @@ export default function PostBody({ content }: PostBodyProps): JSX.Element {
     setZoomedImage({ src: getHighestResSrc(img), alt: img.alt });
   };
 
+  const handleLightboxClose = useCallback(() => setZoomedImage(null), []);
+
   // Browsers don't execute <script> tags inserted via innerHTML, so any script
   // that survived sanitizing (e.g. Getty's embed widget) has to be re-created here.
   // The `data-recreated` marker stops React 18 Strict Mode's double effect
@@ -91,11 +101,7 @@ export default function PostBody({ content }: PostBodyProps): JSX.Element {
     <ContentContainer ref={containerRef}>
       <div onClick={handleContentClick} dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
       {zoomedImage && (
-        <ImageLightbox
-          src={zoomedImage.src}
-          alt={zoomedImage.alt}
-          onClose={() => setZoomedImage(null)}
-        />
+        <ImageLightbox src={zoomedImage.src} alt={zoomedImage.alt} onClose={handleLightboxClose} />
       )}
     </ContentContainer>
   );

--- a/components/world-map.tsx
+++ b/components/world-map.tsx
@@ -5,7 +5,7 @@ import { ComposableMap, Geographies, Geography, ZoomableGroup } from 'react-simp
 import countries110m from 'world-atlas/countries-110m.json';
 import { colours } from '../pages/_app';
 
-type WorldMapProps = {
+export type WorldMapProps = {
   visitedCountries: string[];
   wishListCountries?: string[];
 };
@@ -80,6 +80,14 @@ export default function WorldMap({
     setCenter(DEFAULT_CENTER);
   }, []);
 
+  const handleMoveEnd = useCallback(
+    ({ coordinates, zoom: nextZoom }: { coordinates: [number, number]; zoom: number }) => {
+      setCenter(coordinates);
+      setZoom(nextZoom);
+    },
+    [],
+  );
+
   return (
     <MapWrapper aria-label="World map with countries James has visited highlighted in purple and holiday wish list countries highlighted in blue">
       <Controls>
@@ -108,10 +116,7 @@ export default function WorldMap({
           zoom={zoom}
           minZoom={MIN_ZOOM}
           maxZoom={MAX_ZOOM}
-          onMoveEnd={({ coordinates, zoom: nextZoom }) => {
-            setCenter(coordinates);
-            setZoom(nextZoom);
-          }}
+          onMoveEnd={handleMoveEnd}
           filterZoomEvent={(event: unknown) => {
             const wheelEvent = event as WheelEvent;
             return wheelEvent.type !== 'wheel' || wheelEvent.ctrlKey;

--- a/pages/countries-visited.tsx
+++ b/pages/countries-visited.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import type { GetStaticProps } from 'next';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import type { JSX } from 'react';
 import Container from '../components/container';
@@ -7,8 +8,16 @@ import Layout from '../components/layout';
 import PostHeader from '../components/post-header';
 import PostTitle from '../components/post-title';
 import ShareBar from '../components/share-bar';
-import WorldMap from '../components/world-map';
+import type { WorldMapProps } from '../components/world-map';
 import { fetchDataFromGoogleSheets as fetchSheetById } from '../lib/sheets';
+
+// Lazy-load the world map: react-simple-maps pulls in multiple D3 sub-packages
+// and world-atlas/countries-110m.json (~96 KB), which would bloat the initial
+// JS bundle. Deferring to the client (ssr: false) keeps them out of the page
+// payload entirely and loads them only when the browser is idle.
+// @ts-expect-error -- nodenext requires explicit .js extensions on dynamic
+// import() expressions, but Next.js's bundler resolves .tsx at build time.
+const WorldMap = dynamic<WorldMapProps>(() => import('../components/world-map'), { ssr: false });
 
 type CountriesVisitedProps = {
   transformedData: Record<string, { country: string; visited: string }[]>;


### PR DESCRIPTION
## Summary

Wednesday performance optimisation pass. Three targeted changes:

### 1. Lazy-load `WorldMap` with `next/dynamic` (`pages/countries-visited.tsx`)

`world-map.tsx` statically imports `world-atlas/countries-110m.json` (~96 KB of TopoJSON data) plus `react-simple-maps`, which pulls in several D3 sub-packages (`d3-zoom`, `d3-selection`, `d3-geo`, `topojson-client`). All of this was previously included in the initial JS bundle for the countries-visited page.

Switching to `next/dynamic({ ssr: false })` defers loading the entire map chunk to the client, after first paint. The page's static content (stat block, country list) renders immediately; the interactive map loads asynchronously once the browser is ready.

`WorldMapProps` is now exported from `world-map.tsx` so the dynamically-loaded component retains correct prop types.

### 2. Stable `onMoveEnd` callback in `WorldMap` (`components/world-map.tsx`)

The `onMoveEnd` handler passed to `ZoomableGroup` was an inline arrow function, recreated on every render. Wrapped it with `useCallback` (no dependencies — it only calls state setters with functional updates) so the reference is stable across renders.

### 3. Stable `onClose` callback in `PostBody` (`components/post-body.tsx`)

`ImageLightbox` lists `onClose` in its `useEffect` dependency array (the keyboard event listener). The inline `() => setZoomedImage(null)` was a new function reference on every render of `PostBody`, causing the keydown listener to detach and re-attach every time `zoomedImage` state changed. Extracted it as `handleLightboxClose` with `useCallback`, giving `ImageLightbox` a stable reference.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wkkyoPhjhaQ4q6TkR2kRK)_