### PR TITLE
a11y: fix redundant adjacent links and add missing ARIA live regions

### DIFF
--- a/components/homepage-block.tsx
+++ b/components/homepage-block.tsx
@@ -67,7 +67,11 @@ export default function HomepageBlock({
       style={{ backgroundColor: randomColour }}>
       {label && <LabelBadge>{label}</LabelBadge>}
       {url && title !== RANDOM_PHOTO ? (
-        <StyledLinkImage href={url} aria-label={title}>
+        <StyledLinkImage
+          href={url}
+          aria-label={date ? undefined : title}
+          aria-hidden={date ? true : undefined}
+          tabIndex={date ? -1 : undefined}>
           {imageSrc?.node && size === 1 && (
             <Image
               src={imageSrc.node.sourceUrl}

--- a/components/search-results.tsx
+++ b/components/search-results.tsx
@@ -62,7 +62,7 @@ const SearchResults = ({ searchResults }: SearchResultsProps): JSX.Element => {
                 <SearchCard key={post.slug}>
                   {post.featuredImage?.node.sourceUrl && (
                     <SearchCardImageWrapper>
-                      <Link href={`/${post.slug}`} aria-label={post.title}>
+                      <Link href={`/${post.slug}`} aria-hidden="true" tabIndex={-1}>
                         <Image
                           alt=""
                           src={post.featuredImage.node.sourceUrl}

--- a/pages/stocks.tsx
+++ b/pages/stocks.tsx
@@ -550,10 +550,12 @@ export default function StocksPage(): JSX.Element {
 
         <PageContainer>
           <StatusRow>
-            <span>Connection: {status}</span>
+            <span role="status">Connection: {status}</span>
             <span>Server: {wsUrl}</span>
             {lastUpdated ? (
-              <span>Last update: {new Date(lastUpdated).toLocaleTimeString()}</span>
+              <span aria-live="polite">
+                Last update: {new Date(lastUpdated).toLocaleTimeString()}
+              </span>
             ) : null}
           </StatusRow>
 
@@ -869,6 +871,15 @@ const TableWrapper = styled.div`
     }
     100% {
       background: transparent;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    tr.pulse-up-a,
+    tr.pulse-up-b,
+    tr.pulse-down-a,
+    tr.pulse-down-b {
+      animation: none;
     }
   }
 `;


### PR DESCRIPTION
## Summary

Thursday accessibility & SEO pass. Three files changed, four distinct issues fixed:

- **`components/search-results.tsx`** — Search result cards with a featured image rendered two links to the same post URL (image link with `aria-label` + title link). Screen readers announced the destination twice. Fixed by marking the image link `aria-hidden="true"` / `tabIndex={-1}` — the title link immediately below is the canonical one.

- **`components/homepage-block.tsx`** — The homepage grid blocks that show a post image *and* a title/date overlay produced a `StyledLinkImage` (image link with `aria-label={title}`) and a `StyledLink` (text link) pointing to the same URL. Adjacent duplicate links violate WCAG 2.4.4. Fixed by conditionally suppressing the image link from AT and the tab sequence (`aria-hidden`, `tabIndex=-1`) when a text link will also render. Blocks without a date (icon-only or image-only blocks) retain their image link with the full `aria-label`.

- **`pages/stocks.tsx`** — Two live-region fixes:
  - Added `role="status"` to the connection-status span so WebSocket state changes (`connecting → connected → disconnected`) are announced by screen readers.
  - Added `aria-live="polite"` to the last-updated timestamp span so updates are announced when prices refresh.
  - Added `@media (prefers-reduced-motion: reduce)` to suppress the price-pulse flash animations (`flashUp` / `flashDown`) for users who prefer reduced motion (WCAG 2.3.3).

## Test plan

- [ ] Run the dev server and verify homepage grid blocks are still visually correct and that keyboard Tab skips the redundant image link on post blocks.
- [ ] Run a screen reader (e.g. NVDA + Chrome or VoiceOver + Safari) on the search results page — confirm each result card is announced once, not twice.
- [ ] Load the Stocks page with a WebSocket server; confirm status changes are announced by screen reader without being disruptive.
- [ ] Enable "Reduce Motion" in OS settings and verify stock-price flash animations no longer play.
- [ ] `yarn lint` passes (confirmed locally — 0 errors, 2 pre-existing schema-version infos).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFa63FgBSeUzP7s6aDMfzx)_